### PR TITLE
Legg til integrasjon mot PDL for å hente saker for alle brukers identer

### DIFF
--- a/.nais/app-dev.yml
+++ b/.nais/app-dev.yml
@@ -92,6 +92,7 @@ spec:
     outbound:
       external:
         - host: arenaoppslag.dev-fss-pub.nais.io
+        - host: pdl-api.dev-fss-pub.nais.io
       rules:
         - application: behandlingsflyt
   env:
@@ -103,3 +104,7 @@ spec:
       value: http://behandlingsflyt
     - name: KELVIN_SCOPE
       value: api://dev-gcp.aap.behandlingsflyt/.default
+    - name: INTEGRASJON_PDL_URL
+      value: https://pdl-api.dev-fss-pub.nais.io/graphql
+    - name: INTEGRASJON_PDL_SCOPE
+      value: api://dev-fss.pdl.pdl-api/.default

--- a/.nais/app-prod.yml
+++ b/.nais/app-prod.yml
@@ -85,6 +85,7 @@ spec:
     outbound:
       external:
         - host: arenaoppslag.prod-fss-pub.nais.io
+        - host: pdl-api.prod-fss-pub.nais.io
       rules:
         - application: behandlingsflyt
   env:
@@ -96,3 +97,7 @@ spec:
       value: http://behandlingsflyt
     - name: KELVIN_SCOPE
       value: api://prod-gcp.aap.behandlingsflyt/.default
+    - name: INTEGRASJON_PDL_URL
+      value: https://pdl-api.prod-fss-pub.nais.io/graphql
+    - name: INTEGRASJON_PDL_SCOPE
+      value: api://prod-fss.pdl.pdl-api/.default

--- a/app/main/api/App.kt
+++ b/app/main/api/App.kt
@@ -3,6 +3,8 @@ package api
 import api.arena.ArenaoppslagRestClient
 import api.arena.IArenaoppslagRestClient
 import api.kelvin.dataInsertion
+import api.pdl.IPdlClient
+import api.pdl.PdlClient
 import api.postgres.initDatasource
 import com.papsign.ktor.openapigen.model.info.ContactModel
 import com.papsign.ktor.openapigen.model.info.InfoModel
@@ -65,7 +67,8 @@ fun Application.api(
     prometheus: PrometheusMeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
     config: Config = Config(),
     datasource: DataSource = initDatasource(config.dbConfig, prometheus),
-    arenaRestClient: IArenaoppslagRestClient = ArenaoppslagRestClient(config.arenaoppslag, config.azure)
+    arenaRestClient: IArenaoppslagRestClient = ArenaoppslagRestClient(config.arenaoppslag, config.azure),
+    pdlClient: IPdlClient = PdlClient(),
 ) {
     Migrering.migrate(datasource)
 
@@ -97,7 +100,7 @@ fun Application.api(
     routing {
         authenticate(AZURE) {
             apiRouting {
-                api(datasource, arenaRestClient, prometheus)
+                api(datasource, arenaRestClient, prometheus, pdlClient)
                 dataInsertion(datasource)
             }
         }

--- a/app/main/api/Routes.kt
+++ b/app/main/api/Routes.kt
@@ -55,6 +55,7 @@ enum class Tag(override val description: String) : APITag {
     Maksimum("For å hente maksimumsløsning")
 }
 
+// TODO: tilgangskontroll på alle endepunkter
 fun NormalOpenAPIRoute.api(
     dataSource: DataSource,
     arena: IArenaoppslagRestClient,
@@ -163,8 +164,7 @@ fun NormalOpenAPIRoute.api(
                     sakStatusRepository.hentSakStatus(it)
                 }
             }
-            // TODO: Bør arenasaker også hentes basert på identer fra PDL?
-            val arenaSaker = arena.hentSakerByFnr(callId, requestBody).map {
+            val arenaSaker = arena.hentSakerByFnr(callId, SakerRequest(personIdenter)).map {
                 arenaSakStatusTilDomene(it)
             }
             respond(arenaSaker + kelvinSaker)

--- a/app/main/api/Routes.kt
+++ b/app/main/api/Routes.kt
@@ -153,8 +153,10 @@ fun NormalOpenAPIRoute.api(
                 logger.info("CallID ble ikke gitt på kall mot: /sakerByFnr")
             }
 
-            val personIdenter = pdlClient.hentAlleIdenterForPerson(requestBody.personidentifikatorer.first()).map { it.ident }
-            require(requestBody.personidentifikatorer.all { it in personIdenter }) {
+            val personIdenter = pdlClient.hentAlleIdenterForPerson(requestBody.personidentifikatorer.first()).map {
+                pdlIdent -> pdlIdent.ident
+            }
+            require(requestBody.personidentifikatorer.all { requestIdent -> requestIdent in personIdenter }) {
                 "Liste med personidentifikatorer i request inneholder identer for mer enn én person"
             }
 

--- a/app/main/api/pdl/PdlClient.kt
+++ b/app/main/api/pdl/PdlClient.kt
@@ -38,7 +38,7 @@ class PdlClient : IPdlClient {
             checkNotNull(response.data?.hentIdenter?.identer) {
                 "Fant ingen identer i PDL for person"
             }
-        return pdlIdenter.filter { it.gruppe == "FOLKEREGISTERIDENT" }
+        return pdlIdenter.filter { ident -> ident.gruppe == "FOLKEREGISTERIDENT" }
     }
 
     private fun query(request: GraphQLRequest<PdlRequestVariables>): GraphQLResponse<PdlIdenterData> {

--- a/app/main/api/pdl/PdlClient.kt
+++ b/app/main/api/pdl/PdlClient.kt
@@ -1,0 +1,62 @@
+package api.pdl
+
+import api.util.graphql.GraphQLResponse
+import api.util.graphql.GraphQLResponseHandler
+import api.util.graphql.GraphQLRequest
+import no.nav.aap.komponenter.config.requiredConfigForKey
+import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
+import no.nav.aap.komponenter.httpklient.httpclient.Header
+import no.nav.aap.komponenter.httpklient.httpclient.RestClient
+import no.nav.aap.komponenter.httpklient.httpclient.post
+import no.nav.aap.komponenter.httpklient.httpclient.request.PostRequest
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.ClientCredentialsTokenProvider
+import java.net.URI
+
+interface IPdlClient {
+    fun hentAlleIdenterForPerson(personIdent: String): List<PdlIdent>
+}
+
+class PdlClient : IPdlClient {
+    private val graphqlUrl = URI.create(requiredConfigForKey("integrasjon.pdl.url"))
+    private val config =
+        ClientConfig(
+            scope = requiredConfigForKey("integrasjon.pdl.scope"),
+            additionalHeaders = listOf(Header("Behandlingsnummer", "B287")),
+        )
+
+    private val client =
+        RestClient(
+            config = config,
+            tokenProvider = ClientCredentialsTokenProvider,
+            responseHandler = GraphQLResponseHandler(),
+        )
+
+    override fun hentAlleIdenterForPerson(personIdent: String): List<PdlIdent> {
+        val request = GraphQLRequest(IDENT_QUERY, variables = PdlRequestVariables(personIdent))
+        val response = query(request)
+        val pdlIdenter =
+            checkNotNull(response.data?.hentIdenter?.identer) {
+                "Fant ingen identer i PDL for person"
+            }
+        return pdlIdenter.filter { it.gruppe == "FOLKEREGISTERIDENT" }
+    }
+
+    private fun query(request: GraphQLRequest<PdlRequestVariables>): GraphQLResponse<PdlIdenterData> {
+        val httpRequest = PostRequest(body = request)
+        return requireNotNull(client.post(uri = graphqlUrl, request = httpRequest))
+    }
+}
+
+private const val ident = "\$ident"
+val IDENT_QUERY =
+    """
+    query($ident: ID!) {
+        hentIdenter(ident: $ident, historikk: true) {
+            identer {
+                ident,
+                historisk,
+                gruppe
+            }
+        }
+    }
+    """.trimIndent()

--- a/app/main/api/pdl/PdlIdenterData.kt
+++ b/app/main/api/pdl/PdlIdenterData.kt
@@ -1,0 +1,15 @@
+package api.pdl
+
+data class PdlIdenterData(
+    val hentIdenter: PdlIdenter?,
+)
+
+data class PdlIdenter(
+    val identer: List<PdlIdent>,
+)
+
+data class PdlIdent(
+    val ident: String,
+    val historisk: Boolean,
+    val gruppe: String,
+)

--- a/app/main/api/pdl/PdlRequestVariables.kt
+++ b/app/main/api/pdl/PdlRequestVariables.kt
@@ -1,0 +1,5 @@
+package api.pdl
+
+data class PdlRequestVariables(
+    val ident: String,
+)

--- a/app/main/api/util/graphql/GraphQLError.kt
+++ b/app/main/api/util/graphql/GraphQLError.kt
@@ -1,0 +1,18 @@
+package api.util.graphql
+
+data class GraphQLError(
+    val message: String,
+    val locations: List<GraphQLErrorLocation>,
+    val path: List<String>?,
+    val extensions: GraphQLErrorExtension,
+)
+
+data class GraphQLErrorExtension(
+    val code: String?,
+    val classification: String,
+)
+
+data class GraphQLErrorLocation(
+    val line: Int?,
+    val column: Int?,
+)

--- a/app/main/api/util/graphql/GraphQLRequest.kt
+++ b/app/main/api/util/graphql/GraphQLRequest.kt
@@ -1,0 +1,6 @@
+package api.util.graphql
+
+data class GraphQLRequest<Variables>(
+    val query: String,
+    val variables: Variables,
+)

--- a/app/main/api/util/graphql/GraphQLResponse.kt
+++ b/app/main/api/util/graphql/GraphQLResponse.kt
@@ -1,0 +1,6 @@
+package api.util.graphql
+
+data class GraphQLResponse<Data>(
+    val data: Data?,
+    val errors: List<GraphQLError>?,
+)

--- a/app/main/api/util/graphql/GraphQLResponseHandler.kt
+++ b/app/main/api/util/graphql/GraphQLResponseHandler.kt
@@ -1,0 +1,43 @@
+package api.util.graphql
+
+import no.nav.aap.komponenter.httpklient.httpclient.error.DefaultResponseHandler
+import no.nav.aap.komponenter.httpklient.httpclient.error.RestResponseHandler
+import java.io.InputStream
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import kotlin.collections.isNotEmpty
+import kotlin.collections.joinToString
+import kotlin.text.format
+
+class GraphQLResponseHandler : RestResponseHandler<InputStream> {
+    private val defaultResponseHandler = DefaultResponseHandler()
+
+    override fun <R> håndter(
+        request: HttpRequest,
+        response: HttpResponse<InputStream>,
+        mapper: (InputStream, HttpHeaders) -> R,
+    ): R? {
+        val håndtertResponse = defaultResponseHandler.håndter(request, response, mapper)
+
+        if (håndtertResponse != null && håndtertResponse is GraphQLResponse<*>) {
+            if (håndtertResponse.errors?.isNotEmpty() == true) {
+                throw GraphQLQueryException(
+                    String.format(
+                        "Feil %s ved GraphQL oppslag mot %s",
+                        håndtertResponse.errors.joinToString(transform = GraphQLError::message),
+                        request.uri(),
+                    ),
+                )
+            }
+        }
+
+        return håndtertResponse
+    }
+
+    override fun bodyHandler(): HttpResponse.BodyHandler<InputStream> = defaultResponseHandler.bodyHandler()
+}
+
+class GraphQLQueryException(
+    msg: String,
+) : RuntimeException(msg)


### PR DESCRIPTION
/sakerByFnr henter nå saker fra Kelvin og Arena for alle brukers identer (som først hentes fra PDL). Da slipper konsumenter å sende inn oppdatert liste med alle brukers identer, og. kan heller bare sende inn én.