### PR TITLE
Legg på tilgangskontroll for OBO-tokens på alle endepunkter

### DIFF
--- a/.nais/app-dev.yml
+++ b/.nais/app-dev.yml
@@ -95,6 +95,7 @@ spec:
         - host: pdl-api.dev-fss-pub.nais.io
       rules:
         - application: behandlingsflyt
+        - application: tilgang
   env:
     - name: ARENAOPPSLAG_PROXY_BASE_URL
       value: https://arenaoppslag.dev-fss-pub.nais.io
@@ -108,3 +109,7 @@ spec:
       value: https://pdl-api.dev-fss-pub.nais.io/graphql
     - name: INTEGRASJON_PDL_SCOPE
       value: api://dev-fss.pdl.pdl-api/.default
+    - name: INTEGRASJON_TILGANG_URL
+      value: http://tilgang
+    - name: INTEGRASJON_TILGANG_SCOPE
+      value: api://dev-gcp.aap.tilgang/.default

--- a/.nais/app-prod.yml
+++ b/.nais/app-prod.yml
@@ -88,6 +88,7 @@ spec:
         - host: pdl-api.prod-fss-pub.nais.io
       rules:
         - application: behandlingsflyt
+        - application: tilgang
   env:
     - name: ARENAOPPSLAG_PROXY_BASE_URL
       value: https://arenaoppslag.prod-fss-pub.nais.io
@@ -101,3 +102,7 @@ spec:
       value: https://pdl-api.prod-fss-pub.nais.io/graphql
     - name: INTEGRASJON_PDL_SCOPE
       value: api://prod-fss.pdl.pdl-api/.default
+    - name: INTEGRASJON_TILGANG_URL
+      value: http://tilgang
+    - name: INTEGRASJON_TILGANG_SCOPE
+      value: api://prod-gcp.aap.tilgang/.default


### PR DESCRIPTION
Legger på sjekk på at saksbehandler som spør etter informasjon om bruker, har lov til å se informasjonen vi har på brukeren. Kaller tilgang som så kaller tilgangsmaskinen.