### PR TITLE
Ikke kræsj på oppdatering av identer hvis sak ikke finnes (finnes aldri for saker uten vedtak)

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
@@ -441,7 +441,10 @@ class BehandlingsRepository(private val connection: DBConnection) {
             setRowMapper { it.getLong("id") }
         }
 
-        require(saker.isNotEmpty()) { "Fant ingen saker med saksnummer $saksnummer, kan ikke oppdatere identer" }
+        if (saker.isEmpty()) {
+            log.warn("Fant ingen saker med saksnummer $saksnummer, kan ikke oppdatere identer. Dette er forventet om det ikke finnes vedtak på sak.")
+            return
+        }
         require(saker.size == 1) { "Fant flere saker med saksnummer $saksnummer, kan ikke oppdatere identer" }
 
         val sakId = saker.single()


### PR DESCRIPTION
Driftsendepunkt for å oppdatere identer fungerer ikke før vedtak er fattet hvis api-intern kræsjer (oppdatering av behandlingsflyt og oppdatering av api-intern skjer i samme transaksjon). Må tillate at saksnummer ikke finnes i sak-tabellen ennå.