### PR TITLE
Introduser BehandlingData som lesemodell for hentVedtaksData

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
@@ -287,9 +287,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
         }
     }
 
-    // TODO: ikke returner DTO fra behandlingsflyt her, heller dupliser i kode her
-    // Kommer til å bli kronglete ved modellendringer
-    fun hentVedtaksData(fnr: String, periode: Periode): List<DatadelingDTO> {
+    fun hentVedtaksData(fnr: String, periode: Periode): List<BehandlingData> {
         val sakerIder = connection.queryList(
             """
                 SELECT SAK_ID FROM SAK_PERSON
@@ -332,18 +330,15 @@ class BehandlingsRepository(private val connection: DBConnection) {
             val behandlinger = hentBehandlinger(sak.id)
             behandlinger.map { behandling ->
 
-                DatadelingDTO(
+                BehandlingData(
                     behandlingsId = behandling.id.toString(),
                     behandlingsReferanse = behandling.behandlingReferanse,
                     underveisperiode = hentUnderveis(behandling.id),
-                    rettighetsPeriodeFom = sak.rettighetsPeriode.fom,
-                    rettighetsPeriodeTom = sak.rettighetsPeriode.tom,
                     behandlingStatus = behandling.behandlingStatus,
                     vedtaksDato = behandling.vedtaksDato,
-                    sak = SakDTO(
+                    sak = SakInfo(
                         saksnummer = sak.saksnummer,
                         status = sak.status,
-                        fnr = emptyList()
                     ),
                     tilkjent = hentTilkjentYtelse(behandling.id),
                     rettighetsTypeTidsLinje = hentRettighetsTypeTidslinje(behandling.id),

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/DatadelingDto.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/DatadelingDto.kt
@@ -5,6 +5,42 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 
+data class BehandlingData(
+    val behandlingsId: String,
+    val behandlingsReferanse: String,
+    val underveisperiode: List<UnderveisDTO>,
+    val behandlingStatus: KelvinBehandlingStatus,
+    val vedtaksDato: LocalDate,
+    val sak: SakInfo,
+    val tilkjent: List<TilkjentDTO>,
+    val rettighetsTypeTidsLinje: List<RettighetsTypePeriode>,
+    val samId: String?,
+    val vedtakId: Long,
+    val beregningsgrunnlag: BigDecimal?,
+    val nyttVedtak: Boolean,
+    val stansOpphørVurdering: Set<GjeldendeStansEllerOpphørDTO>?,
+)
+
+data class SakInfo(
+    val saksnummer: String,
+    val status: KelvinSakStatus,
+)
+
+fun DatadelingDTO.tilBehandlingData(): BehandlingData = BehandlingData(
+    behandlingsId = this.behandlingsId,
+    behandlingsReferanse = this.behandlingsReferanse,
+    underveisperiode = this.underveisperiode,
+    behandlingStatus = this.behandlingStatus,
+    vedtaksDato = this.vedtaksDato,
+    sak = SakInfo(saksnummer = this.sak.saksnummer, status = this.sak.status),
+    tilkjent = this.tilkjent,
+    rettighetsTypeTidsLinje = this.rettighetsTypeTidsLinje,
+    samId = this.samId,
+    vedtakId = this.vedtakId,
+    beregningsgrunnlag = this.beregningsgrunnlag,
+    nyttVedtak = this.nyttVedtak,
+    stansOpphørVurdering = this.stansOpphørVurdering,
+)
 
 data class DatadelingDTO(
     val underveisperiode: List<UnderveisDTO>,

--- a/app/src/main/kotlin/no/nav/aap/api/util/PeriodeFunksjoner.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/util/PeriodeFunksjoner.kt
@@ -1,9 +1,9 @@
 package no.nav.aap.api.util
 
 import no.nav.aap.api.intern.Periode
-import no.nav.aap.api.postgres.DatadelingDTO
+import no.nav.aap.api.postgres.BehandlingData
 
-fun perioderMedAAp(input: List<DatadelingDTO>): List<Periode> {
+fun perioderMedAAp(input: List<BehandlingData>): List<Periode> {
     return input.flatMap { sak ->
         sak.rettighetsTypeTidsLinje.map { segment ->
             Periode(segment.fom, segment.tom)

--- a/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
@@ -17,6 +17,7 @@ import no.nav.aap.api.intern.Maksimum
 import no.nav.aap.api.intern.Medium
 import no.nav.aap.api.intern.PerioderResponse
 import no.nav.aap.api.kelvin.tilDomene
+import no.nav.aap.api.postgres.tilBehandlingData
 import no.nav.aap.api.util.AzureTokenGen
 import no.nav.aap.api.util.Fakes
 import no.nav.aap.api.util.PostgresTestBase
@@ -396,7 +397,7 @@ class BehandlingsDataTest : PostgresTestBase() {
 
             assertEquals(HttpStatusCode.OK, perioderResponseObo.status)
             assertEquals(
-                perioderMedAAp(listOf(testObject.tilDomene())),
+                perioderMedAAp(listOf(testObject.tilDomene().tilBehandlingData())),
                 perioderResponseObo.body<PerioderResponse>().perioder
             )
 
@@ -470,7 +471,7 @@ class BehandlingsDataTest : PostgresTestBase() {
 
     @Test
     fun `kan hente perioder fra vedtaksdata`() {
-        val result = perioderMedAAp(listOf(testObject.tilDomene()))
+        val result = perioderMedAAp(listOf(testObject.tilDomene().tilBehandlingData()))
 
         assertEquals(1, result.size)
         assertEquals(


### PR DESCRIPTION
## Bakgrunn

`hentVedtaksData` returnerte tidligere `List<DatadelingDTO>` — samme type som brukes for skriving (`lagreBehandling`). Det gjør det vanskelig å endre lesemodellen uavhengig av skrivemodellen.

## Endringer

- Ny `BehandlingData`-klasse som lesemodell for `hentVedtaksData`
- Ny `SakInfo`-klasse (kun `saksnummer` og `status`) i stedet for `SakDTO` (som har `fnr` og `opprettetTidspunkt` kun relevant for skriving)
- Fjernet de deprecated feltene `rettighetsPeriodeFom`/`rettighetsPeriodeTom` fra lesemodellen
- Fjernet TODO-kommentar som nå er løst
- Hjelpefunksjon `DatadelingDTO.tilBehandlingData()` for bruk i tester