### PR TITLE
Fjern DTO-suffix fra klasser som ikke brukes som DTO

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
@@ -1,16 +1,16 @@
 package no.nav.aap.api.kelvin
 
-import no.nav.aap.api.postgres.AvslagsårsakDTO
-import no.nav.aap.api.postgres.GjeldendeStansEllerOpphørDTO
+import no.nav.aap.api.postgres.Avslagsårsak
+import no.nav.aap.api.postgres.GjeldendeStansEllerOpphør
 import no.nav.aap.api.postgres.KelvinBehandlingStatus
 import no.nav.aap.api.postgres.KelvinSakStatus
-import no.nav.aap.api.postgres.StansEllerOpphørEnumDTODomene
+import no.nav.aap.api.postgres.StansEllerOpphør
 import no.nav.aap.behandlingsflyt.kontrakt.behandling.Status
 import no.nav.aap.behandlingsflyt.kontrakt.datadeling.*
 import no.nav.aap.komponenter.type.Periode
 
-fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): no.nav.aap.api.postgres.DatadelingDTO {
-    return no.nav.aap.api.postgres.DatadelingDTO(
+fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): no.nav.aap.api.postgres.DatadelingIntern {
+    return no.nav.aap.api.postgres.DatadelingIntern(
         underveisperiode = this.underveisperiode.map { it.tilDomene() },
         rettighetsPeriodeFom = this.rettighetsPeriodeFom,
         rettighetsPeriodeTom = this.rettighetsPeriodeTom,
@@ -26,21 +26,21 @@ fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): no.nav.aap.api.postgre
         beregningsgrunnlag = this.beregningsgrunnlag,
         nyttVedtak = nyttVedtak,
         stansOpphørVurdering = this.stansOpphørVurdering?.map {
-            GjeldendeStansEllerOpphørDTO(
+            GjeldendeStansEllerOpphør(
                 fom = it.fom,
                 opprettet = it.opprettet,
                 vurdering = when(it.vurdering){
-                    StansEllerOpphørEnumDTO.STANS -> StansEllerOpphørEnumDTODomene.STANS
-                    StansEllerOpphørEnumDTO.OPPHØR -> StansEllerOpphørEnumDTODomene.OPPHØR
+                    StansEllerOpphørEnumDTO.STANS -> StansEllerOpphør.STANS
+                    StansEllerOpphørEnumDTO.OPPHØR -> StansEllerOpphør.OPPHØR
                 },
-                avslagsårsaker = it.avslagsårsaker.map { AvslagsårsakDTO.valueOf(it.name) }.toSet()
+                avslagsårsaker = it.avslagsårsaker.map { Avslagsårsak.valueOf(it.name) }.toSet()
             )
         }?.toSet().orEmpty()
     )
 }
 
-fun SakDTO.tilDomene(): no.nav.aap.api.postgres.SakDTO {
-    return no.nav.aap.api.postgres.SakDTO(
+fun SakDTO.tilDomene(): no.nav.aap.api.postgres.Sak {
+    return no.nav.aap.api.postgres.Sak(
         saksnummer = this.saksnummer,
         status = this.status.tilDomene(),
         fnr = this.fnr,
@@ -48,8 +48,8 @@ fun SakDTO.tilDomene(): no.nav.aap.api.postgres.SakDTO {
     )
 }
 
-fun UnderveisDTO.tilDomene(): no.nav.aap.api.postgres.UnderveisDTO {
-    return no.nav.aap.api.postgres.UnderveisDTO(
+fun UnderveisDTO.tilDomene(): no.nav.aap.api.postgres.UnderveisIntern {
+    return no.nav.aap.api.postgres.UnderveisIntern(
         underveisFom = this.underveisFom,
         underveisTom = this.underveisFom,
         meldeperiodeFom = this.meldeperiodeFom,
@@ -69,8 +69,8 @@ fun Status.tilDomene(): KelvinBehandlingStatus {
     }
 }
 
-fun TilkjentDTO.tilDomene(): no.nav.aap.api.postgres.TilkjentDTO {
-    return no.nav.aap.api.postgres.TilkjentDTO(
+fun TilkjentDTO.tilDomene(): no.nav.aap.api.postgres.TilkjentPeriode {
+    return no.nav.aap.api.postgres.TilkjentPeriode(
         tilkjentFom = this.tilkjentFom,
         tilkjentTom = this.tilkjentTom,
         dagsats = this.dagsats,

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
@@ -23,7 +23,7 @@ import no.nav.aap.api.intern.PeriodeDTO
 class BehandlingsRepository(private val connection: DBConnection) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    fun lagreBehandling(behandling: DatadelingDTO) {
+    fun lagreBehandling(behandling: DatadelingIntern) {
         val gammelSak = connection.queryFirstOrNull(
             """SELECT ID FROM SAK WHERE SAKSNUMMER = ?""".trimIndent()
         ) {
@@ -432,7 +432,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
         }
     }
 
-    private fun hentUnderveis(behandlingId: Long): List<UnderveisDTO> {
+    private fun hentUnderveis(behandlingId: Long): List<UnderveisIntern> {
         return connection.queryList(
             """
                 SELECT * FROM UNDERVEIS
@@ -445,7 +445,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
             setRowMapper { row ->
                 val periode = row.getPeriode("PERIODE")
                 val meldePeriode = row.getPeriode("MELDEPERIODE")
-                UnderveisDTO(
+                UnderveisIntern(
                     underveisFom = periode.fom,
                     underveisTom = periode.tom,
                     meldeperiodeFom = meldePeriode.fom,
@@ -458,7 +458,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
         }
     }
 
-    private fun hentStansOpphør(behandlingId: Long): Set<GjeldendeStansEllerOpphørDTO> {
+    private fun hentStansOpphør(behandlingId: Long): Set<GjeldendeStansEllerOpphør> {
         return connection.queryList(
             """SELECT * FROM stans_opphor_vurdering WHERE stans_opphor_grunnlag_id IN (SELECT id FROM stans_opphor_grunnlag WHERE behandling_id = ?)""".trimIndent()
         ) {
@@ -467,18 +467,18 @@ class BehandlingsRepository(private val connection: DBConnection) {
             }
             setRowMapper {
 
-                GjeldendeStansEllerOpphørDTO(
+                GjeldendeStansEllerOpphør(
                     fom = it.getLocalDate("fom"),
                     opprettet = it.getLocalDateTime("opprettet_tid")
                         .toInstant(java.time.ZoneOffset.UTC),
-                    vurdering = StansEllerOpphørEnumDTODomene.valueOf(it.getString("vedtakstype")),
+                    vurdering = StansEllerOpphør.valueOf(it.getString("vedtakstype")),
                     avslagsårsaker = hentAvslagsårsaker(it.getLong("id"))
                 )
             }
         }.toSet()
     }
 
-    private fun hentAvslagsårsaker(stansOpphørVurderingId: Long): Set<AvslagsårsakDTO>{
+    private fun hentAvslagsårsaker(stansOpphørVurderingId: Long): Set<Avslagsårsak>{
         return connection.queryList(
             """SELECT * FROM avslagsarsak WHERE stans_opphor_vurdering_id = ?""".trimIndent()
         ){
@@ -486,12 +486,12 @@ class BehandlingsRepository(private val connection: DBConnection) {
                 setLong(1, stansOpphørVurderingId)
             }
             setRowMapper { row ->
-                row.getEnum<AvslagsårsakDTO>("avslagsarsak")
+                row.getEnum<Avslagsårsak>("avslagsarsak")
             }
         }.toSet()
     }
 
-    private fun hentTilkjentYtelse(behandlingId: Long): List<TilkjentDTO> {
+    private fun hentTilkjentYtelse(behandlingId: Long): List<TilkjentPeriode> {
         return connection.queryList(
             """
                 SELECT * FROM TILKJENT_PERIODE
@@ -503,7 +503,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
         ) {
             setParams { setLong(1, behandlingId) }
             setRowMapper {
-                TilkjentDTO(
+                TilkjentPeriode(
                     tilkjentFom = it.getPeriode("PERIODE").fom,
                     tilkjentTom = it.getPeriode("PERIODE").tom,
                     dagsats = it.getBigDecimal("DAGSATS").toInt(),

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/DatadelingIntern.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/DatadelingIntern.kt
@@ -1,6 +1,5 @@
 package no.nav.aap.api.postgres
 
-import no.nav.aap.behandlingsflyt.kontrakt.datadeling.StansEllerOpphørEnumDTO
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -9,17 +8,17 @@ import java.time.LocalDateTime
 data class BehandlingData(
     val behandlingsId: String,
     val behandlingsReferanse: String,
-    val underveisperiode: List<UnderveisDTO>,
+    val underveisperiode: List<UnderveisIntern>,
     val behandlingStatus: KelvinBehandlingStatus,
     val vedtaksDato: LocalDate,
     val sak: SakInfo,
-    val tilkjent: List<TilkjentDTO>,
+    val tilkjent: List<TilkjentPeriode>,
     val rettighetsTypeTidsLinje: List<RettighetsTypePeriode>,
     val samId: String?,
     val vedtakId: Long,
     val beregningsgrunnlag: BigDecimal?,
     val nyttVedtak: Boolean,
-    val stansOpphørVurdering: Set<GjeldendeStansEllerOpphørDTO>?,
+    val stansOpphørVurdering: Set<GjeldendeStansEllerOpphør>?,
 )
 
 data class SakInfo(
@@ -27,7 +26,7 @@ data class SakInfo(
     val status: KelvinSakStatus,
 )
 
-fun DatadelingDTO.tilBehandlingData(): BehandlingData = BehandlingData(
+fun DatadelingIntern.tilBehandlingData(): BehandlingData = BehandlingData(
     behandlingsId = this.behandlingsId,
     behandlingsReferanse = this.behandlingsReferanse,
     underveisperiode = this.underveisperiode,
@@ -43,8 +42,8 @@ fun DatadelingDTO.tilBehandlingData(): BehandlingData = BehandlingData(
     stansOpphørVurdering = this.stansOpphørVurdering,
 )
 
-data class DatadelingDTO(
-    val underveisperiode: List<UnderveisDTO>,
+data class DatadelingIntern(
+    val underveisperiode: List<UnderveisIntern>,
     @Deprecated("Ikke del disse utad.")
     val rettighetsPeriodeFom: LocalDate,
     @Deprecated("Ikke del disse utad.")
@@ -52,53 +51,53 @@ data class DatadelingDTO(
     val behandlingStatus: KelvinBehandlingStatus,
     val behandlingsId: String,
     val vedtaksDato: LocalDate,
-    val sak: SakDTO,
-    val tilkjent: List<TilkjentDTO>,
+    val sak: Sak,
+    val tilkjent: List<TilkjentPeriode>,
     val rettighetsTypeTidsLinje: List<RettighetsTypePeriode>,
     val behandlingsReferanse: String,
     val samId: String? = null,
     val vedtakId: Long,
     val beregningsgrunnlag: BigDecimal?,
     val nyttVedtak: Boolean,
-    val stansOpphørVurdering: Set<GjeldendeStansEllerOpphørDTO>?
+    val stansOpphørVurdering: Set<GjeldendeStansEllerOpphør>?
 )
 
-data class GjeldendeStansEllerOpphørDTO(
+data class GjeldendeStansEllerOpphør(
     val fom: LocalDate,
     val opprettet: Instant,
-    val vurdering: StansEllerOpphørEnumDTODomene,
-    val avslagsårsaker: Set<AvslagsårsakDTO>,
+    val vurdering: StansEllerOpphør,
+    val avslagsårsaker: Set<Avslagsårsak>,
 )
 
-public enum class AvslagsårsakDTO(
-    public val type: StansEllerOpphørEnumDTO,
+enum class Avslagsårsak(
+    val type: StansEllerOpphør,
 ) {
-    BRUKER_OVER_67(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_RETT_PA_SYKEPENGEERSTATNING(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_RETT_PA_STUDENT(StansEllerOpphørEnumDTO.OPPHØR),
-    VARIGHET_OVERSKREDET_STUDENT(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_SYKDOM_AV_VISS_VARIGHET(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_SYKDOM_SKADE_LYTE_VESENTLIGDEL(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_NOK_REDUSERT_ARBEIDSEVNE(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_BEHOV_FOR_OPPFOLGING(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_MEDLEM(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_OPPFYLT_OPPHOLDSKRAV_EØS(StansEllerOpphørEnumDTO.STANS),
-    ANNEN_FULL_YTELSE(StansEllerOpphørEnumDTO.OPPHØR),
-    INNTEKTSTAP_DEKKES_ETTER_ANNEN_LOVGIVNING(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_RETT_PA_AAP_UNDER_BEHANDLING_AV_UFORE(StansEllerOpphørEnumDTO.OPPHØR),
-    VARIGHET_OVERSKREDET_OVERGANG_UFORE(StansEllerOpphørEnumDTO.OPPHØR),
-    VARIGHET_OVERSKREDET_ARBEIDSSØKER(StansEllerOpphørEnumDTO.OPPHØR),
-    IKKE_RETT_PA_AAP_I_PERIODE_SOM_ARBEIDSSOKER(StansEllerOpphørEnumDTO.STANS),
-    IKKE_RETT_UNDER_STRAFFEGJENNOMFØRING(StansEllerOpphørEnumDTO.STANS),
-    BRUDD_PÅ_AKTIVITETSPLIKT_STANS(StansEllerOpphørEnumDTO.STANS),
-    BRUDD_PÅ_AKTIVITETSPLIKT_OPPHØR(StansEllerOpphørEnumDTO.OPPHØR),
-    BRUDD_PÅ_OPPHOLDSKRAV_STANS(StansEllerOpphørEnumDTO.STANS),
-    BRUDD_PÅ_OPPHOLDSKRAV_OPPHØR(StansEllerOpphørEnumDTO.OPPHØR),
-    ORDINÆRKVOTE_BRUKT_OPP(StansEllerOpphørEnumDTO.OPPHØR),
-    SYKEPENGEERSTATNINGKVOTE_BRUKT_OPP(StansEllerOpphørEnumDTO.OPPHØR),
+    BRUKER_OVER_67(StansEllerOpphør.OPPHØR),
+    IKKE_RETT_PA_SYKEPENGEERSTATNING(StansEllerOpphør.OPPHØR),
+    IKKE_RETT_PA_STUDENT(StansEllerOpphør.OPPHØR),
+    VARIGHET_OVERSKREDET_STUDENT(StansEllerOpphør.OPPHØR),
+    IKKE_SYKDOM_AV_VISS_VARIGHET(StansEllerOpphør.OPPHØR),
+    IKKE_SYKDOM_SKADE_LYTE_VESENTLIGDEL(StansEllerOpphør.OPPHØR),
+    IKKE_NOK_REDUSERT_ARBEIDSEVNE(StansEllerOpphør.OPPHØR),
+    IKKE_BEHOV_FOR_OPPFOLGING(StansEllerOpphør.OPPHØR),
+    IKKE_MEDLEM(StansEllerOpphør.OPPHØR),
+    IKKE_OPPFYLT_OPPHOLDSKRAV_EØS(StansEllerOpphør.STANS),
+    ANNEN_FULL_YTELSE(StansEllerOpphør.OPPHØR),
+    INNTEKTSTAP_DEKKES_ETTER_ANNEN_LOVGIVNING(StansEllerOpphør.OPPHØR),
+    IKKE_RETT_PA_AAP_UNDER_BEHANDLING_AV_UFORE(StansEllerOpphør.OPPHØR),
+    VARIGHET_OVERSKREDET_OVERGANG_UFORE(StansEllerOpphør.OPPHØR),
+    VARIGHET_OVERSKREDET_ARBEIDSSØKER(StansEllerOpphør.OPPHØR),
+    IKKE_RETT_PA_AAP_I_PERIODE_SOM_ARBEIDSSOKER(StansEllerOpphør.STANS),
+    IKKE_RETT_UNDER_STRAFFEGJENNOMFØRING(StansEllerOpphør.STANS),
+    BRUDD_PÅ_AKTIVITETSPLIKT_STANS(StansEllerOpphør.STANS),
+    BRUDD_PÅ_AKTIVITETSPLIKT_OPPHØR(StansEllerOpphør.OPPHØR),
+    BRUDD_PÅ_OPPHOLDSKRAV_STANS(StansEllerOpphør.STANS),
+    BRUDD_PÅ_OPPHOLDSKRAV_OPPHØR(StansEllerOpphør.OPPHØR),
+    ORDINÆRKVOTE_BRUKT_OPP(StansEllerOpphør.OPPHØR),
+    SYKEPENGEERSTATNINGKVOTE_BRUKT_OPP(StansEllerOpphør.OPPHØR),
 }
 
-enum class StansEllerOpphørEnumDTODomene {
+enum class StansEllerOpphør {
     STANS,
     OPPHØR
 }
@@ -109,7 +108,7 @@ data class RettighetsTypePeriode(
     val verdi: String
 )
 
-data class SakDTO(
+data class Sak(
     val saksnummer: String,
     val status: KelvinSakStatus,
     val fnr: List<String>,
@@ -119,7 +118,7 @@ data class SakDTO(
 /**
  * @param samordningUføregradering Svarer til prosent uføre. 100% bør medføre 0% gradering.
  */
-data class TilkjentDTO(
+data class TilkjentPeriode(
     val tilkjentFom: LocalDate,
     val tilkjentTom: LocalDate,
     val dagsats: Int,
@@ -132,7 +131,7 @@ data class TilkjentDTO(
     val barnetillegg: BigDecimal
 )
 
-data class UnderveisDTO(
+data class UnderveisIntern(
     val underveisFom: LocalDate,
     val underveisTom: LocalDate,
     val meldeperiodeFom: LocalDate,

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
@@ -32,14 +32,14 @@ class BehandlingsRepositoryTest {
         dataSource.close()
     }
 
-    private val testVedtak = DatadelingDTO(
+    private val testVedtak = DatadelingIntern(
         underveisperiode = listOf(),
         rettighetsPeriodeFom = LocalDate.of(2021, 1, 1),
         rettighetsPeriodeTom = LocalDate.of(2022, 4, 1),
         behandlingStatus = KelvinBehandlingStatus.UTREDES,
         behandlingsId = "123",
         vedtaksDato = LocalDate.now(),
-        sak = SakDTO(
+        sak = Sak(
             saksnummer = "ABCDE",
             status = KelvinSakStatus.OPPRETTET,
             fnr = listOf("123445"),
@@ -142,7 +142,7 @@ class BehandlingsRepositoryTest {
         val originalIdent = "55555555555"
 
         val behandling = testVedtak.copy(
-            sak = SakDTO(saksnummer, KelvinSakStatus.LØPENDE, listOf(originalIdent))
+            sak = Sak(saksnummer, KelvinSakStatus.LØPENDE, listOf(originalIdent))
         )
 
         dataSource.transaction {
@@ -184,16 +184,16 @@ class BehandlingsRepositoryTest {
     @Test
     fun `lagre og hente ut stansOpphørVurdering`() {
         val vurderinger = setOf(
-            GjeldendeStansEllerOpphørDTO(
+            GjeldendeStansEllerOpphør(
                 fom = LocalDate.of(2021, 6, 1),
                 opprettet = Instant.now(),
-                vurdering = StansEllerOpphørEnumDTODomene.STANS,
+                vurdering = StansEllerOpphør.STANS,
                 avslagsårsaker = emptySet()
             ),
-            GjeldendeStansEllerOpphørDTO(
+            GjeldendeStansEllerOpphør(
                 fom = LocalDate.of(2021, 9, 1),
                 opprettet = Instant.now(),
-                vurdering = StansEllerOpphørEnumDTODomene.OPPHØR,
+                vurdering = StansEllerOpphør.OPPHØR,
                 avslagsårsaker = emptySet()
             ),
         )
@@ -218,24 +218,24 @@ class BehandlingsRepositoryTest {
     @Test
     fun `re-lagring av behandling erstatter eksisterende stansOpphørVurdering`() {
         val opprinnelige = setOf(
-            GjeldendeStansEllerOpphørDTO(
+            GjeldendeStansEllerOpphør(
                 fom = LocalDate.of(2021, 6, 1),
                 opprettet = Instant.now(),
-                vurdering = StansEllerOpphørEnumDTODomene.STANS,
+                vurdering = StansEllerOpphør.STANS,
                 avslagsårsaker = emptySet()
             ),
-            GjeldendeStansEllerOpphørDTO(
+            GjeldendeStansEllerOpphør(
                 fom = LocalDate.of(2021, 9, 1),
                 opprettet = Instant.now(),
-                vurdering = StansEllerOpphørEnumDTODomene.OPPHØR,
+                vurdering = StansEllerOpphør.OPPHØR,
                 avslagsårsaker = emptySet()
             ),
         )
         val oppdaterte = setOf(
-            GjeldendeStansEllerOpphørDTO(
+            GjeldendeStansEllerOpphør(
                 fom = LocalDate.of(2021, 11, 1),
                 opprettet = Instant.now(),
-                vurdering = StansEllerOpphørEnumDTODomene.STANS,
+                vurdering = StansEllerOpphør.STANS,
                 avslagsårsaker = emptySet()
             ),
         )
@@ -259,6 +259,6 @@ class BehandlingsRepositoryTest {
         val stansVurderinger = hentet.single().stansOpphørVurdering
         assertThat(stansVurderinger).hasSize(1)
         assertThat(stansVurderinger!!.single().fom).isEqualTo(LocalDate.of(2021, 11, 1))
-        assertThat(stansVurderinger.single().vurdering).isEqualTo(StansEllerOpphørEnumDTODomene.STANS)
+        assertThat(stansVurderinger.single().vurdering).isEqualTo(StansEllerOpphør.STANS)
     }
 }


### PR DESCRIPTION
Disse klassene brukes ikke som DTO. Så fjerner `DTO`-suffikset som en del klasser har. Kun mekansik renameing i intellij.