### PR TITLE
Flytt mapping ut av repository

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/Routes.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/Routes.kt
@@ -36,6 +36,8 @@ import java.time.Clock
 import java.time.LocalDate
 import java.util.*
 import javax.sql.DataSource
+import no.nav.aap.api.kelvin.AktivitetsfaseService
+import no.nav.aap.api.kelvin.DsopService
 
 private val logger = LoggerFactory.getLogger("App")
 
@@ -136,8 +138,8 @@ fun NormalOpenAPIRoute.api(
                 sjekkTilgangTilPerson(requestBody.personidentifikator, token())
                 val vedtakRequest = requestBody.tilKontrakt()
                 val aktfaseKelvin = dataSource.transaction { connection ->
-                    val behandlingsRepository = BehandlingsRepository(connection)
-                    behandlingsRepository.hentPerioderMedAktivitetsfase(
+                    val aktivitetsfaseService = AktivitetsfaseService(connection)
+                    aktivitetsfaseService.hentPerioderMedAktivitetsfase(
                         vedtakRequest.personidentifikator,
                         Periode(vedtakRequest.fraOgMedDato, vedtakRequest.tilOgMedDato)
                     )
@@ -468,8 +470,8 @@ fun NormalOpenAPIRoute.api(
                     sjekkTilgangTilPerson(requestBody.personIdent, token())
 
                     val kelvinVedtak = dataSource.transaction { connection ->
-                        val behandlingsRepository = BehandlingsRepository(connection)
-                        behandlingsRepository.hentDsopVedtak(
+                        val dsopService = DsopService(connection)
+                        dsopService.hentDsopVedtak(
                             requestBody.personIdent,
                             utrekksperiode
                         )

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/AktivitetsfaseService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/AktivitetsfaseService.kt
@@ -1,0 +1,39 @@
+package no.nav.aap.api.kelvin
+
+import no.nav.aap.api.intern.PeriodeInkludert11_17
+import no.nav.aap.api.postgres.BehandlingsRepository
+import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.tidslinje.somTidslinje
+import no.nav.aap.komponenter.type.Periode
+
+class AktivitetsfaseService(
+    private val behandlingsRepository: BehandlingsRepository,
+) {
+    constructor(connection: DBConnection): this(
+        behandlingsRepository = BehandlingsRepository(connection),
+    )
+
+    fun hentPerioderMedAktivitetsfase(fnr: String, periode: Periode): List<PeriodeInkludert11_17> {
+        val vedtaksdata = behandlingsRepository.hentVedtaksData(fnr, periode)
+
+        return vedtaksdata.flatMap {
+            it.rettighetsTypeTidsLinje
+                .somTidslinje({ rettighetsTypePeriode ->
+                    Periode(
+                        rettighetsTypePeriode.fom,
+                        rettighetsTypePeriode.tom
+                    )
+                }, { rettighetstype -> rettighetstype.verdi })
+                .komprimer()
+                .segmenter()
+                .map { (periode, verdi) ->
+                    PeriodeInkludert11_17(
+                        no.nav.aap.api.intern.Periode(
+                            periode.fom,
+                            periode.tom
+                        ), aktivitetsfaseNavn = verdi, aktivitetsfaseKode = verdi
+                    )
+                }
+        }
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/DsopService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/DsopService.kt
@@ -1,0 +1,54 @@
+package no.nav.aap.api.kelvin
+
+import java.time.LocalDate
+import no.nav.aap.api.intern.DsopRettighetsTypeDTO
+import no.nav.aap.api.intern.DsopStatusDTO
+import no.nav.aap.api.intern.DsopVedtakDTO
+import no.nav.aap.api.intern.DsopVedtaksTypeDTO
+import no.nav.aap.api.intern.PeriodeDTO
+import no.nav.aap.api.postgres.BehandlingsRepository
+import no.nav.aap.api.postgres.RettighetsTypePeriode
+import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.tidslinje.somTidslinje
+import no.nav.aap.komponenter.type.Periode
+
+class DsopService(
+    private val behandlingsRepository: BehandlingsRepository,
+) {
+    constructor(connection: DBConnection): this(
+        behandlingsRepository = BehandlingsRepository(connection),
+    )
+
+    fun hentDsopVedtak(fnr: String, uttrekksperiode: Periode): List<DsopVedtakDTO> {
+        val vedtaksdata = behandlingsRepository.hentVedtaksData(fnr, uttrekksperiode)
+
+        return vedtaksdata.flatMap {
+            it.rettighetsTypeTidsLinje
+                .somTidslinje({ rettighetsTypePeriode ->
+                    Periode(
+                        rettighetsTypePeriode.fom,
+                        rettighetsTypePeriode.tom
+                    )
+                }, { rettighetstype -> rettighetstype.verdi })
+                .komprimer()
+                .segmenter()
+                .map { (periode, verdi) -> RettighetsTypePeriode(periode.fom, periode.tom, verdi) }
+                .map { rettighetsTypePeriode ->
+                    DsopVedtakDTO(
+                        vedtakId = it.behandlingsId,
+                        vedtakStatus = when (rettighetsTypePeriode.tom >= LocalDate.now()) {
+                            true -> DsopStatusDTO.LØPENDE
+                            else -> DsopStatusDTO.AVSLUTTET
+                        },
+                        virkningsperiode = PeriodeDTO(
+                            rettighetsTypePeriode.fom,
+                            rettighetsTypePeriode.tom
+                        ),
+                        utfall = "JA",
+                        aktivitetsfase = DsopRettighetsTypeDTO.valueOf(rettighetsTypePeriode.verdi),
+                        vedtaksType = if (it.nyttVedtak) DsopVedtaksTypeDTO.O else DsopVedtaksTypeDTO.E,
+                    )
+                }
+        }
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
@@ -1,24 +1,17 @@
 package no.nav.aap.api.postgres
 
 import com.papsign.ktor.openapigen.annotations.properties.description.Description
-import no.nav.aap.api.intern.Kilde
-import no.nav.aap.api.intern.PeriodeInkludert11_17
-import no.nav.aap.api.intern.VedtakUtenUtbetaling
-import no.nav.aap.komponenter.dbconnect.DBConnection
-import no.nav.aap.komponenter.tidslinje.somTidslinje
-import no.nav.aap.komponenter.type.Periode
-import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.math.roundToInt
-import no.nav.aap.api.intern.DsopRettighetsTypeDTO
-import no.nav.aap.api.intern.DsopStatusDTO
-import no.nav.aap.api.intern.DsopVedtakDTO
-import no.nav.aap.api.intern.DsopVedtaksTypeDTO
-import no.nav.aap.api.intern.PeriodeDTO
+import no.nav.aap.api.intern.Kilde
+import no.nav.aap.api.intern.VedtakUtenUtbetaling
+import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.type.Periode
+import org.slf4j.LoggerFactory
 
 class BehandlingsRepository(private val connection: DBConnection) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -245,63 +238,6 @@ class BehandlingsRepository(private val connection: DBConnection) {
         }
     }
 
-    fun hentDsopVedtak(fnr: String, uttrekksperiode: Periode): List<DsopVedtakDTO> {
-        val vedtaksdata = hentVedtaksData(fnr, uttrekksperiode)
-
-        return vedtaksdata.flatMap {
-            it.rettighetsTypeTidsLinje
-                .somTidslinje({ rettighetsTypePeriode ->
-                    Periode(
-                        rettighetsTypePeriode.fom,
-                        rettighetsTypePeriode.tom
-                    )
-                }, { rettighetstype -> rettighetstype.verdi })
-                .komprimer()
-                .segmenter()
-                .map { (periode, verdi) -> RettighetsTypePeriode(periode.fom, periode.tom, verdi) }
-                .map { rettighetsTypePeriode ->
-                    DsopVedtakDTO(
-                        vedtakId = it.behandlingsId,
-                        vedtakStatus = when (rettighetsTypePeriode.tom >= LocalDate.now()) {
-                            true -> DsopStatusDTO.LØPENDE
-                            else -> DsopStatusDTO.AVSLUTTET
-                        },
-                        virkningsperiode = PeriodeDTO(
-                            rettighetsTypePeriode.fom,
-                            rettighetsTypePeriode.tom
-                        ),
-                        utfall = "JA",
-                        aktivitetsfase = DsopRettighetsTypeDTO.valueOf(rettighetsTypePeriode.verdi),
-                        vedtaksType = if (it.nyttVedtak) DsopVedtaksTypeDTO.O else DsopVedtaksTypeDTO.E,
-                    )
-                }
-        }
-    }
-
-    fun hentPerioderMedAktivitetsfase(fnr: String, periode: Periode): List<PeriodeInkludert11_17> {
-        val vedtaksdata = hentVedtaksData(fnr, periode)
-
-        return vedtaksdata.flatMap {
-            it.rettighetsTypeTidsLinje
-                .somTidslinje({ rettighetsTypePeriode ->
-                    Periode(
-                        rettighetsTypePeriode.fom,
-                        rettighetsTypePeriode.tom
-                    )
-                }, { rettighetstype -> rettighetstype.verdi })
-                .komprimer()
-                .segmenter()
-                .map { (periode, verdi) ->
-                    PeriodeInkludert11_17(
-                        no.nav.aap.api.intern.Periode(
-                            periode.fom,
-                            periode.tom
-                        ), aktivitetsfaseNavn = verdi, aktivitetsfaseKode = verdi
-                    )
-                }
-        }
-    }
-
     fun hentVedtaksData(fnr: String, periode: Periode): List<BehandlingData> {
         val sakerIder = connection.queryList(
             """
@@ -339,12 +275,9 @@ class BehandlingsRepository(private val connection: DBConnection) {
             }
         }
 
-
-
         return saker.flatMap { sak ->
             val behandlinger = hentBehandlinger(sak.id)
             behandlinger.map { behandling ->
-
                 BehandlingData(
                     behandlingsId = behandling.id.toString(),
                     behandlingsReferanse = behandling.behandlingReferanse,
@@ -366,8 +299,6 @@ class BehandlingsRepository(private val connection: DBConnection) {
                 )
             }
         }
-
-
     }
 
     private fun hentBeregningsGrunnlag(behandlingId: Long): BigDecimal? {

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/MeldekortService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/MeldekortService.kt
@@ -7,11 +7,12 @@ import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.type.Periode
 import java.time.Clock
 import java.time.LocalDate
+import no.nav.aap.api.kelvin.DsopService
 
 class MeldekortService(connection: DBConnection, val pdlGateway: IPdlGateway, clock: Clock) {
     val meldekortDetaljerRepository = MeldekortDetaljerRepository(connection)
     val vedtakService = VedtakService(BehandlingsRepository(connection), clock)
-    val behandlingsRepository = BehandlingsRepository(connection)
+    val dsopService = DsopService(connection)
 
     private fun hentAlleMeldekort(
         personIdentifikator: String,
@@ -48,7 +49,7 @@ class MeldekortService(connection: DBConnection, val pdlGateway: IPdlGateway, cl
         fom: LocalDate,
         tom: LocalDate
     ): List<Meldekort> {
-        val kelvinVedtak = behandlingsRepository.hentDsopVedtak(
+        val kelvinVedtak = dsopService.hentDsopVedtak(
             personIdentifikator,
             Periode(fom, tom)
         )

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
@@ -10,6 +10,7 @@ import no.nav.aap.api.intern.DsopStatusDTO
 import no.nav.aap.api.intern.DsopVedtakDTO
 import no.nav.aap.api.intern.DsopVedtaksTypeDTO
 import no.nav.aap.api.intern.PeriodeDTO
+import no.nav.aap.api.kelvin.DsopService
 import no.nav.aap.behandlingsflyt.kontrakt.statistikk.RettighetsType
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
@@ -98,7 +99,7 @@ class BehandlingsRepositoryTest {
         }
 
         val res = dataSource.transaction {
-            BehandlingsRepository(it).hentDsopVedtak(
+            DsopService(it).hentDsopVedtak(
                 "123445",
                 Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1))
             )


### PR DESCRIPTION
Metodene `BehandlingsRepository::hentDsopVedtak` og `BehandlingsRepository::hentPerioderMedAktivitetsfase` er rene tranformasjoner av domene-objekter. Flytter ut av repository inn i egne services.