### PR TITLE
Flytt services ut av postgres-pakken

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/Routes.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/Routes.kt
@@ -38,6 +38,10 @@ import java.util.*
 import javax.sql.DataSource
 import no.nav.aap.api.kelvin.AktivitetsfaseService
 import no.nav.aap.api.kelvin.DsopService
+import no.nav.aap.api.kelvin.KelvinBehandlingStatus
+import no.nav.aap.api.kelvin.KelvinSakStatus
+import no.nav.aap.api.kelvin.MeldekortService
+import no.nav.aap.api.kelvin.VedtakService
 
 private val logger = LoggerFactory.getLogger("App")
 

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/DatadelingIntern.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/DatadelingIntern.kt
@@ -1,4 +1,4 @@
-package no.nav.aap.api.postgres
+package no.nav.aap.api.kelvin
 
 import java.math.BigDecimal
 import java.time.Instant

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/DsopService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/DsopService.kt
@@ -7,7 +7,6 @@ import no.nav.aap.api.intern.DsopVedtakDTO
 import no.nav.aap.api.intern.DsopVedtaksTypeDTO
 import no.nav.aap.api.intern.PeriodeDTO
 import no.nav.aap.api.postgres.BehandlingsRepository
-import no.nav.aap.api.postgres.RettighetsTypePeriode
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.tidslinje.somTidslinje
 import no.nav.aap.komponenter.type.Periode

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
@@ -1,16 +1,11 @@
 package no.nav.aap.api.kelvin
 
-import no.nav.aap.api.postgres.Avslagsårsak
-import no.nav.aap.api.postgres.GjeldendeStansEllerOpphør
-import no.nav.aap.api.postgres.KelvinBehandlingStatus
-import no.nav.aap.api.postgres.KelvinSakStatus
-import no.nav.aap.api.postgres.StansEllerOpphør
 import no.nav.aap.behandlingsflyt.kontrakt.behandling.Status
 import no.nav.aap.behandlingsflyt.kontrakt.datadeling.*
 import no.nav.aap.komponenter.type.Periode
 
-fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): no.nav.aap.api.postgres.DatadelingIntern {
-    return no.nav.aap.api.postgres.DatadelingIntern(
+fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): DatadelingIntern {
+    return DatadelingIntern(
         underveisperiode = this.underveisperiode.map { it.tilDomene() },
         rettighetsPeriodeFom = this.rettighetsPeriodeFom,
         rettighetsPeriodeTom = this.rettighetsPeriodeTom,
@@ -29,7 +24,7 @@ fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): no.nav.aap.api.postgre
             GjeldendeStansEllerOpphør(
                 fom = it.fom,
                 opprettet = it.opprettet,
-                vurdering = when(it.vurdering){
+                vurdering = when (it.vurdering) {
                     StansEllerOpphørEnumDTO.STANS -> StansEllerOpphør.STANS
                     StansEllerOpphørEnumDTO.OPPHØR -> StansEllerOpphør.OPPHØR
                 },
@@ -39,8 +34,8 @@ fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): no.nav.aap.api.postgre
     )
 }
 
-fun SakDTO.tilDomene(): no.nav.aap.api.postgres.Sak {
-    return no.nav.aap.api.postgres.Sak(
+fun SakDTO.tilDomene(): Sak {
+    return Sak(
         saksnummer = this.saksnummer,
         status = this.status.tilDomene(),
         fnr = this.fnr,
@@ -48,8 +43,8 @@ fun SakDTO.tilDomene(): no.nav.aap.api.postgres.Sak {
     )
 }
 
-fun UnderveisDTO.tilDomene(): no.nav.aap.api.postgres.UnderveisIntern {
-    return no.nav.aap.api.postgres.UnderveisIntern(
+fun UnderveisDTO.tilDomene(): UnderveisIntern {
+    return UnderveisIntern(
         underveisFom = this.underveisFom,
         underveisTom = this.underveisTom,
         meldeperiodeFom = this.meldeperiodeFom,
@@ -69,8 +64,8 @@ fun Status.tilDomene(): KelvinBehandlingStatus {
     }
 }
 
-fun TilkjentDTO.tilDomene(): no.nav.aap.api.postgres.TilkjentPeriode {
-    return no.nav.aap.api.postgres.TilkjentPeriode(
+fun TilkjentDTO.tilDomene(): TilkjentPeriode {
+    return TilkjentPeriode(
         tilkjentFom = this.tilkjentFom,
         tilkjentTom = this.tilkjentTom,
         dagsats = this.dagsats,
@@ -84,8 +79,8 @@ fun TilkjentDTO.tilDomene(): no.nav.aap.api.postgres.TilkjentPeriode {
     )
 }
 
-fun RettighetsTypePeriode.tilDomene(): no.nav.aap.api.postgres.RettighetsTypePeriode {
-    return no.nav.aap.api.postgres.RettighetsTypePeriode(
+fun no.nav.aap.behandlingsflyt.kontrakt.datadeling.RettighetsTypePeriode.tilDomene(): RettighetsTypePeriode {
+    return RettighetsTypePeriode(
         fom = this.fom,
         tom = this.tom,
         verdi = this.verdi

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/MeldekortService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/MeldekortService.kt
@@ -1,13 +1,13 @@
-package no.nav.aap.api.postgres
+package no.nav.aap.api.kelvin
 
-import no.nav.aap.api.intern.VedtakUtenUtbetaling
-import no.nav.aap.api.kelvin.Meldekort
-import no.nav.aap.api.pdl.IPdlGateway
-import no.nav.aap.komponenter.dbconnect.DBConnection
-import no.nav.aap.komponenter.type.Periode
 import java.time.Clock
 import java.time.LocalDate
-import no.nav.aap.api.kelvin.DsopService
+import no.nav.aap.api.intern.VedtakUtenUtbetaling
+import no.nav.aap.api.pdl.IPdlGateway
+import no.nav.aap.api.postgres.BehandlingsRepository
+import no.nav.aap.api.postgres.MeldekortDetaljerRepository
+import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.type.Periode
 
 class MeldekortService(connection: DBConnection, val pdlGateway: IPdlGateway, clock: Clock) {
     val meldekortDetaljerRepository = MeldekortDetaljerRepository(connection)
@@ -82,4 +82,3 @@ class MeldekortService(connection: DBConnection, val pdlGateway: IPdlGateway, cl
         return vedtak.firstOrNull()
     }
 }
-

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
@@ -1,14 +1,23 @@
-package no.nav.aap.api.postgres
+package no.nav.aap.api.kelvin
 
-import no.nav.aap.api.intern.*
+import java.time.Clock
+import java.time.LocalDate
+import no.nav.aap.api.intern.Kilde
+import no.nav.aap.api.intern.Maksimum
+import no.nav.aap.api.intern.Medium
+import no.nav.aap.api.intern.UtbetalingMedMer
+import no.nav.aap.api.intern.Vedtak
+import no.nav.aap.api.intern.VedtakUtenUtbetaling
+import no.nav.aap.api.postgres.BehandlingsRepository
+import no.nav.aap.api.postgres.TilkjentDB
+import no.nav.aap.api.postgres.VedtakUtenUtbetalingUtenPeriode
+import no.nav.aap.api.postgres.weekdaysBetween
 import no.nav.aap.api.utledVedtakStatus
 import no.nav.aap.behandlingsflyt.kontrakt.sak.Status
 import no.nav.aap.komponenter.tidslinje.JoinStyle
 import no.nav.aap.komponenter.tidslinje.Segment
 import no.nav.aap.komponenter.tidslinje.Tidslinje
 import no.nav.aap.komponenter.type.Periode
-import java.time.Clock
-import java.time.LocalDate
 
 class VedtakService(
     private val behandlingsRepository: BehandlingsRepository,
@@ -95,7 +104,7 @@ class VedtakService(
                             barnetillegg = left.verdi.barnMedStonad * (right?.verdi?.segmenter()
                                 ?.first()?.verdi?.barnetilleggsats?.toInt()
                                 ?: 0),
-                            barnetilleggSats = left.verdi.barnetilleggSats?.toInt()?:0,
+                            barnetilleggSats = left.verdi.barnetilleggSats?.toInt() ?: 0,
                             vedtaksTypeKode = null,
                             vedtaksTypeNavn = null,
                             utbetaling = right?.verdi?.filter {

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
@@ -9,6 +9,17 @@ import java.time.LocalDateTime
 import kotlin.math.roundToInt
 import no.nav.aap.api.intern.Kilde
 import no.nav.aap.api.intern.VedtakUtenUtbetaling
+import no.nav.aap.api.kelvin.Avslagsårsak
+import no.nav.aap.api.kelvin.BehandlingData
+import no.nav.aap.api.kelvin.DatadelingIntern
+import no.nav.aap.api.kelvin.GjeldendeStansEllerOpphør
+import no.nav.aap.api.kelvin.KelvinBehandlingStatus
+import no.nav.aap.api.kelvin.KelvinSakStatus
+import no.nav.aap.api.kelvin.RettighetsTypePeriode
+import no.nav.aap.api.kelvin.SakInfo
+import no.nav.aap.api.kelvin.StansEllerOpphør
+import no.nav.aap.api.kelvin.TilkjentPeriode
+import no.nav.aap.api.kelvin.UnderveisIntern
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.type.Periode
 import org.slf4j.LoggerFactory

--- a/app/src/main/kotlin/no/nav/aap/api/util/PeriodeFunksjoner.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/util/PeriodeFunksjoner.kt
@@ -1,7 +1,7 @@
 package no.nav.aap.api.util
 
 import no.nav.aap.api.intern.Periode
-import no.nav.aap.api.postgres.BehandlingData
+import no.nav.aap.api.kelvin.BehandlingData
 
 fun perioderMedAAp(input: List<BehandlingData>): List<Periode> {
     return input.flatMap { sak ->

--- a/app/src/test/kotlin/no/nav/aap/api/RoutesTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/RoutesTest.kt
@@ -1,8 +1,8 @@
 package no.nav.aap.api
 
 import java.time.LocalDate
-import no.nav.aap.api.postgres.KelvinBehandlingStatus
-import no.nav.aap.api.postgres.KelvinSakStatus
+import no.nav.aap.api.kelvin.KelvinBehandlingStatus
+import no.nav.aap.api.kelvin.KelvinSakStatus
 import no.nav.aap.komponenter.type.Periode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest

--- a/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
@@ -17,7 +17,7 @@ import no.nav.aap.api.intern.Maksimum
 import no.nav.aap.api.intern.Medium
 import no.nav.aap.api.intern.PerioderResponse
 import no.nav.aap.api.kelvin.tilDomene
-import no.nav.aap.api.postgres.tilBehandlingData
+import no.nav.aap.api.kelvin.tilBehandlingData
 import no.nav.aap.api.util.AzureTokenGen
 import no.nav.aap.api.util.Fakes
 import no.nav.aap.api.util.PostgresTestBase

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
@@ -10,7 +10,14 @@ import no.nav.aap.api.intern.DsopStatusDTO
 import no.nav.aap.api.intern.DsopVedtakDTO
 import no.nav.aap.api.intern.DsopVedtaksTypeDTO
 import no.nav.aap.api.intern.PeriodeDTO
+import no.nav.aap.api.kelvin.DatadelingIntern
 import no.nav.aap.api.kelvin.DsopService
+import no.nav.aap.api.kelvin.GjeldendeStansEllerOpphør
+import no.nav.aap.api.kelvin.KelvinBehandlingStatus
+import no.nav.aap.api.kelvin.KelvinSakStatus
+import no.nav.aap.api.kelvin.RettighetsTypePeriode
+import no.nav.aap.api.kelvin.Sak
+import no.nav.aap.api.kelvin.StansEllerOpphør
 import no.nav.aap.behandlingsflyt.kontrakt.statistikk.RettighetsType
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource


### PR DESCRIPTION
En del filer i `postgres`-pakken har ikke noe med postgres/database å gjøre. De brukes for Kelvin, så flytter de til `kelvin`-pakken.