### PR TITLE
Flytt hjelpemetode for dsop-meldekort ut av repository

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/Routes.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/Routes.kt
@@ -42,6 +42,7 @@ import no.nav.aap.api.kelvin.KelvinBehandlingStatus
 import no.nav.aap.api.kelvin.KelvinSakStatus
 import no.nav.aap.api.kelvin.MeldekortService
 import no.nav.aap.api.kelvin.VedtakService
+import no.nav.aap.api.kelvin.slåSammenMeldeperioder
 
 private val logger = LoggerFactory.getLogger("App")
 

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/DsopService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/DsopService.kt
@@ -1,6 +1,9 @@
 package no.nav.aap.api.kelvin
 
+import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.LocalDateTime
+import no.nav.aap.api.intern.DsopMeldekortDTO
 import no.nav.aap.api.intern.DsopRettighetsTypeDTO
 import no.nav.aap.api.intern.DsopStatusDTO
 import no.nav.aap.api.intern.DsopVedtakDTO
@@ -50,4 +53,25 @@ class DsopService(
                 }
         }
     }
+}
+
+fun List<DsopMeldekortDTO>.slåSammenMeldeperioder(): List<DsopMeldekortDTO> {
+    return this
+        .groupBy { it.periode }
+        .values.map { meldekort ->
+            DsopMeldekortDTO(
+                periode = meldekort.first().periode,
+                antallTimerArbeidet = BigDecimal.ZERO,
+                timerArbeidetPerDag = meldekort.sortedBy { it.sistOppdatert }
+                    .flatMap { it.timerArbeidetPerDag }
+                    .groupingBy { it.dag }.reduce { _, accumulator, element ->
+                        accumulator.copy(timerArbeidet = element.timerArbeidet)
+                    }.values.toList(),
+                sistOppdatert = meldekort.maxByOrNull { it.sistOppdatert }?.sistOppdatert
+                    ?: LocalDateTime.MIN,
+            ).let { meldekort ->
+                meldekort.copy(antallTimerArbeidet = meldekort.timerArbeidetPerDag.sumOf { it.timerArbeidet }
+                    .toBigDecimal())
+            }
+        }
 }

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/MeldekortDetaljerRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/MeldekortDetaljerRepository.kt
@@ -1,13 +1,10 @@
 package no.nav.aap.api.postgres
 
+import java.time.LocalDate
 import no.nav.aap.api.kelvin.Meldekort
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.dbconnect.Row
 import org.slf4j.LoggerFactory
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import no.nav.aap.api.intern.DsopMeldekortDTO
 
 class MeldekortDetaljerRepository(private val connection: DBConnection) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -181,23 +178,3 @@ class MeldekortDetaljerRepository(private val connection: DBConnection) {
 
 }
 
-fun List<DsopMeldekortDTO>.slåSammenMeldeperioder(): List<DsopMeldekortDTO> {
-    return this
-        .groupBy { it.periode }
-        .values.map { meldekort ->
-            DsopMeldekortDTO(
-                periode = meldekort.first().periode,
-                antallTimerArbeidet = BigDecimal.ZERO,
-                timerArbeidetPerDag = meldekort.sortedBy { it.sistOppdatert }
-                    .flatMap { it.timerArbeidetPerDag }
-                    .groupingBy { it.dag }.reduce { _, accumulator, element ->
-                        accumulator.copy(timerArbeidet = element.timerArbeidet)
-                    }.values.toList(),
-                sistOppdatert = meldekort.maxByOrNull { it.sistOppdatert }?.sistOppdatert
-                    ?: LocalDateTime.MIN,
-            ).let { meldekort ->
-                meldekort.copy(antallTimerArbeidet = meldekort.timerArbeidetPerDag.sumOf { it.timerArbeidet }
-                    .toBigDecimal())
-            }
-        }
-}

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/MeldekortDetaljerRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/MeldekortDetaljerRepositoryTest.kt
@@ -14,6 +14,7 @@ import java.time.LocalDateTime
 import no.nav.aap.api.intern.DsopMeldekortDTO
 import no.nav.aap.api.intern.DsopTimerArbeidetPerDagDTO
 import no.nav.aap.api.intern.PeriodeDTO
+import no.nav.aap.api.kelvin.slåSammenMeldeperioder
 
 class MeldekortDetaljerRepositoryTest {
     private lateinit var dataSource: TestDataSource


### PR DESCRIPTION
Metoden `slåSammenMeldeperioder` har ingen database-logikk og handler om dsop-meldekort, så flytter fra repository til `DsopService`.