### PR TITLE
Slå sammen BehandlingIntern og BehandlingData til Behandling

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
@@ -4,14 +4,17 @@ import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import no.nav.aap.komponenter.type.Periode
 
-data class BehandlingData(
+data class Behandling(
     val behandlingsId: String,
     val behandlingsReferanse: String,
+    @Deprecated("Ikke del denne utad.")
+    val rettighetsperiode: Periode,
     val underveisperiode: List<UnderveisIntern>,
     val behandlingStatus: KelvinBehandlingStatus,
     val vedtaksDato: LocalDate,
-    val sak: SakInfo,
+    val sak: Sak,
     val tilkjent: List<TilkjentPeriode>,
     val rettighetsTypeTidsLinje: List<RettighetsTypePeriode>,
     val samId: String?,
@@ -19,47 +22,6 @@ data class BehandlingData(
     val beregningsgrunnlag: BigDecimal?,
     val nyttVedtak: Boolean,
     val stansOpphørVurdering: Set<GjeldendeStansEllerOpphør>?,
-)
-
-data class SakInfo(
-    val saksnummer: String,
-    val status: KelvinSakStatus,
-)
-
-fun DatadelingIntern.tilBehandlingData(): BehandlingData = BehandlingData(
-    behandlingsId = this.behandlingsId,
-    behandlingsReferanse = this.behandlingsReferanse,
-    underveisperiode = this.underveisperiode,
-    behandlingStatus = this.behandlingStatus,
-    vedtaksDato = this.vedtaksDato,
-    sak = SakInfo(saksnummer = this.sak.saksnummer, status = this.sak.status),
-    tilkjent = this.tilkjent,
-    rettighetsTypeTidsLinje = this.rettighetsTypeTidsLinje,
-    samId = this.samId,
-    vedtakId = this.vedtakId,
-    beregningsgrunnlag = this.beregningsgrunnlag,
-    nyttVedtak = this.nyttVedtak,
-    stansOpphørVurdering = this.stansOpphørVurdering,
-)
-
-data class DatadelingIntern(
-    val underveisperiode: List<UnderveisIntern>,
-    @Deprecated("Ikke del disse utad.")
-    val rettighetsPeriodeFom: LocalDate,
-    @Deprecated("Ikke del disse utad.")
-    val rettighetsPeriodeTom: LocalDate,
-    val behandlingStatus: KelvinBehandlingStatus,
-    val behandlingsId: String,
-    val vedtaksDato: LocalDate,
-    val sak: Sak,
-    val tilkjent: List<TilkjentPeriode>,
-    val rettighetsTypeTidsLinje: List<RettighetsTypePeriode>,
-    val behandlingsReferanse: String,
-    val samId: String? = null,
-    val vedtakId: Long,
-    val beregningsgrunnlag: BigDecimal?,
-    val nyttVedtak: Boolean,
-    val stansOpphørVurdering: Set<GjeldendeStansEllerOpphør>?
 )
 
 data class GjeldendeStansEllerOpphør(
@@ -111,8 +73,7 @@ data class RettighetsTypePeriode(
 data class Sak(
     val saksnummer: String,
     val status: KelvinSakStatus,
-    val fnr: List<String>,
-    val opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
+    val opprettetTidspunkt: LocalDateTime,
 )
 
 /**

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
@@ -4,11 +4,10 @@ import no.nav.aap.behandlingsflyt.kontrakt.behandling.Status
 import no.nav.aap.behandlingsflyt.kontrakt.datadeling.*
 import no.nav.aap.komponenter.type.Periode
 
-fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): DatadelingIntern {
-    return DatadelingIntern(
+fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): Behandling {
+    return Behandling(
         underveisperiode = this.underveisperiode.map { it.tilDomene() },
-        rettighetsPeriodeFom = this.rettighetsPeriodeFom,
-        rettighetsPeriodeTom = this.rettighetsPeriodeTom,
+        rettighetsperiode = Periode(this.rettighetsPeriodeFom, this.rettighetsPeriodeTom),
         behandlingStatus = this.behandlingStatus.tilDomene(),
         behandlingsId = this.behandlingsId,
         vedtaksDato = this.vedtaksDato,
@@ -38,7 +37,6 @@ fun SakDTO.tilDomene(): Sak {
     return Sak(
         saksnummer = this.saksnummer,
         status = this.status.tilDomene(),
-        fnr = this.fnr,
         opprettetTidspunkt = this.opprettetTidspunkt
     )
 }

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/Route.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/Route.kt
@@ -91,7 +91,7 @@ fun NormalOpenAPIRoute.dataInsertion(
             val nyttVedtak = dataSource.transaction { connection ->
                 val behandlingsRepository = BehandlingsRepository(connection)
                 val nyttVedtak = behandlingsRepository.erNyttVedtak(body.sak.fnr.first())
-                behandlingsRepository.lagreBehandling(body.tilDomene(nyttVedtak))
+                behandlingsRepository.lagreBehandling(body.sak.fnr, body.tilDomene(nyttVedtak))
                 nyttVedtak
             }
 

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
@@ -10,13 +10,12 @@ import kotlin.math.roundToInt
 import no.nav.aap.api.intern.Kilde
 import no.nav.aap.api.intern.VedtakUtenUtbetaling
 import no.nav.aap.api.kelvin.Avslagsårsak
-import no.nav.aap.api.kelvin.BehandlingData
-import no.nav.aap.api.kelvin.DatadelingIntern
+import no.nav.aap.api.kelvin.Behandling
 import no.nav.aap.api.kelvin.GjeldendeStansEllerOpphør
 import no.nav.aap.api.kelvin.KelvinBehandlingStatus
 import no.nav.aap.api.kelvin.KelvinSakStatus
 import no.nav.aap.api.kelvin.RettighetsTypePeriode
-import no.nav.aap.api.kelvin.SakInfo
+import no.nav.aap.api.kelvin.Sak
 import no.nav.aap.api.kelvin.StansEllerOpphør
 import no.nav.aap.api.kelvin.TilkjentPeriode
 import no.nav.aap.api.kelvin.UnderveisIntern
@@ -27,7 +26,7 @@ import org.slf4j.LoggerFactory
 class BehandlingsRepository(private val connection: DBConnection) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    fun lagreBehandling(behandling: DatadelingIntern) {
+    fun lagreBehandling(fnr: List<String>, behandling: Behandling) {
         val gammelSak = connection.queryFirstOrNull(
             """SELECT ID FROM SAK WHERE SAKSNUMMER = ?""".trimIndent()
         ) {
@@ -49,17 +48,14 @@ class BehandlingsRepository(private val connection: DBConnection) {
         ) {
             setParams {
                 setString(1, behandling.sak.status.toString())
-                setPeriode(
-                    2,
-                    Periode(behandling.rettighetsPeriodeFom, behandling.rettighetsPeriodeTom)
-                )
+                setPeriode(2, behandling.rettighetsperiode)
                 setString(3, behandling.sak.saksnummer)
             }
         }
 
         connection.executeBatch(
             """DELETE FROM SAK_PERSON WHERE SAK_ID = ? AND PERSON_IDENT = ?""".trimIndent(),
-            behandling.sak.fnr
+            fnr
         ) {
             setParams {
                 setLong(1, sakId)
@@ -72,7 +68,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
                 INSERT INTO SAK_PERSON (SAK_ID, PERSON_IDENT)
                 VALUES (?, ?)
             """.trimIndent(),
-            behandling.sak.fnr
+            fnr
         ) {
             setParams { fnr ->
                 setLong(1, sakId)
@@ -249,7 +245,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
         }
     }
 
-    fun hentVedtaksData(fnr: String, periode: Periode): List<BehandlingData> {
+    fun hentVedtaksData(fnr: String, periode: Periode): List<Behandling> {
         val sakerIder = connection.queryList(
             """
                 SELECT SAK_ID FROM SAK_PERSON
@@ -289,15 +285,16 @@ class BehandlingsRepository(private val connection: DBConnection) {
         return saker.flatMap { sak ->
             val behandlinger = hentBehandlinger(sak.id)
             behandlinger.map { behandling ->
-                BehandlingData(
+                Behandling(
                     behandlingsId = behandling.id.toString(),
                     behandlingsReferanse = behandling.behandlingReferanse,
                     underveisperiode = hentUnderveis(behandling.id),
                     behandlingStatus = behandling.behandlingStatus,
                     vedtaksDato = behandling.vedtaksDato,
-                    sak = SakInfo(
+                    sak = Sak(
                         saksnummer = sak.saksnummer,
                         status = sak.status,
+                        opprettetTidspunkt = behandling.opprettetTidspunkt,
                     ),
                     tilkjent = hentTilkjentYtelse(behandling.id),
                     rettighetsTypeTidsLinje = hentRettighetsTypeTidslinje(behandling.id),
@@ -306,7 +303,8 @@ class BehandlingsRepository(private val connection: DBConnection) {
                     beregningsgrunnlag = hentBeregningsGrunnlag(behandling.id)
                         ?: BigDecimal.ZERO, // TODO!!!
                     nyttVedtak = behandling.førstegangsbehandling,
-                    stansOpphørVurdering = hentStansOpphør(behandling.id)
+                    stansOpphørVurdering = hentStansOpphør(behandling.id),
+                    rettighetsperiode = sak.rettighetsPeriode,
                 )
             }
         }
@@ -364,7 +362,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
                     id = row.getLong("ID"),
                     behandlingStatus = row.getEnum("STATUS"),
                     vedtaksDato = row.getLocalDate("VEDTAKS_DATO"),
-                    opprettetTidspunkt = row.getLocalDate("OPPRETTET_TID"),
+                    opprettetTidspunkt = row.getLocalDateTime("OPPRETTET_TID"),
                     behandlingReferanse = row.getString("BEHANDLING_REFERANSE"),
                     samid = row.getStringOrNull("SAMID"),
                     vedtakId = row.getLongOrNull("VEDTAKID"),
@@ -514,7 +512,7 @@ data class BehandlingDB(
     val id: Long,
     val behandlingStatus: KelvinBehandlingStatus,
     val vedtaksDato: LocalDate,
-    val opprettetTidspunkt: LocalDate,
+    val opprettetTidspunkt: LocalDateTime,
     val behandlingReferanse: String,
     val samid: String? = null,
     val vedtakId: Long? = null,

--- a/app/src/main/kotlin/no/nav/aap/api/util/PeriodeFunksjoner.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/util/PeriodeFunksjoner.kt
@@ -1,9 +1,9 @@
 package no.nav.aap.api.util
 
 import no.nav.aap.api.intern.Periode
-import no.nav.aap.api.kelvin.BehandlingData
+import no.nav.aap.api.kelvin.Behandling
 
-fun perioderMedAAp(input: List<BehandlingData>): List<Periode> {
+fun perioderMedAAp(input: List<Behandling>): List<Periode> {
     return input.flatMap { sak ->
         sak.rettighetsTypeTidsLinje.map { segment ->
             Periode(segment.fom, segment.tom)

--- a/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
@@ -17,7 +17,6 @@ import no.nav.aap.api.intern.Maksimum
 import no.nav.aap.api.intern.Medium
 import no.nav.aap.api.intern.PerioderResponse
 import no.nav.aap.api.kelvin.tilDomene
-import no.nav.aap.api.kelvin.tilBehandlingData
 import no.nav.aap.api.util.AzureTokenGen
 import no.nav.aap.api.util.Fakes
 import no.nav.aap.api.util.PostgresTestBase
@@ -397,7 +396,7 @@ class BehandlingsDataTest : PostgresTestBase() {
 
             assertEquals(HttpStatusCode.OK, perioderResponseObo.status)
             assertEquals(
-                perioderMedAAp(listOf(testObject.tilDomene().tilBehandlingData())),
+                perioderMedAAp(listOf(testObject.tilDomene())),
                 perioderResponseObo.body<PerioderResponse>().perioder
             )
 
@@ -471,7 +470,7 @@ class BehandlingsDataTest : PostgresTestBase() {
 
     @Test
     fun `kan hente perioder fra vedtaksdata`() {
-        val result = perioderMedAAp(listOf(testObject.tilDomene().tilBehandlingData()))
+        val result = perioderMedAAp(listOf(testObject.tilDomene()))
 
         assertEquals(1, result.size)
         assertEquals(

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
@@ -10,7 +10,7 @@ import no.nav.aap.api.intern.DsopStatusDTO
 import no.nav.aap.api.intern.DsopVedtakDTO
 import no.nav.aap.api.intern.DsopVedtaksTypeDTO
 import no.nav.aap.api.intern.PeriodeDTO
-import no.nav.aap.api.kelvin.DatadelingIntern
+import no.nav.aap.api.kelvin.Behandling
 import no.nav.aap.api.kelvin.DsopService
 import no.nav.aap.api.kelvin.GjeldendeStansEllerOpphør
 import no.nav.aap.api.kelvin.KelvinBehandlingStatus
@@ -40,17 +40,16 @@ class BehandlingsRepositoryTest {
         dataSource.close()
     }
 
-    private val testVedtak = DatadelingIntern(
+    private val fnr = listOf("123445")
+    private val testVedtak = Behandling(
         underveisperiode = listOf(),
-        rettighetsPeriodeFom = LocalDate.of(2021, 1, 1),
-        rettighetsPeriodeTom = LocalDate.of(2022, 4, 1),
+        rettighetsperiode = Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 4, 1)),
         behandlingStatus = KelvinBehandlingStatus.UTREDES,
         behandlingsId = "123",
         vedtaksDato = LocalDate.now(),
         sak = Sak(
             saksnummer = "ABCDE",
             status = KelvinSakStatus.OPPRETTET,
-            fnr = listOf("123445"),
             opprettetTidspunkt = LocalDateTime.now()
         ),
         tilkjent = listOf(),
@@ -82,9 +81,7 @@ class BehandlingsRepositoryTest {
     @Test
     fun `lagre og hente ut`() {
         dataSource.transaction {
-            BehandlingsRepository(it).lagreBehandling(
-                testVedtak
-            )
+            BehandlingsRepository(it).lagreBehandling(fnr, testVedtak)
         }
 
         val uthentetVedtak = dataSource.transaction {
@@ -100,9 +97,7 @@ class BehandlingsRepositoryTest {
     @Test
     fun `lagre ned og hente ut dsop-vedtak, komprimerer like rettighetstypeperioder`() {
         dataSource.transaction {
-            BehandlingsRepository(it).lagreBehandling(
-                testVedtak
-            )
+            BehandlingsRepository(it).lagreBehandling(fnr, testVedtak)
         }
 
         val res = dataSource.transaction {
@@ -150,13 +145,13 @@ class BehandlingsRepositoryTest {
         val originalIdent = "55555555555"
 
         val behandling = testVedtak.copy(
-            sak = Sak(saksnummer, KelvinSakStatus.LØPENDE, listOf(originalIdent))
+            sak = Sak(saksnummer, KelvinSakStatus.LØPENDE, testVedtak.sak.opprettetTidspunkt)
         )
 
         dataSource.transaction {
             val repo = BehandlingsRepository(it)
 
-            repo.lagreBehandling(behandling)
+            repo.lagreBehandling(listOf(originalIdent), behandling)
 
             val vedtak =
                 repo.hentVedtaksData(originalIdent, Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1)))
@@ -170,7 +165,7 @@ class BehandlingsRepositoryTest {
         dataSource.transaction {
             val repo = BehandlingsRepository(it)
 
-            repo.lagreBehandling(behandling)
+            repo.lagreBehandling(listOf(originalIdent), behandling)
 
             val vedtakFinnesIkke =
                 repo.hentVedtaksData(nyIdent, Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1)))
@@ -208,6 +203,7 @@ class BehandlingsRepositoryTest {
 
         dataSource.transaction {
             BehandlingsRepository(it).lagreBehandling(
+                fnr,
                 testVedtak.copy(stansOpphørVurdering = vurderinger)
             )
         }
@@ -250,11 +246,13 @@ class BehandlingsRepositoryTest {
 
         dataSource.transaction {
             BehandlingsRepository(it).lagreBehandling(
+                fnr,
                 testVedtak.copy(stansOpphørVurdering = opprinnelige)
             )
         }
         dataSource.transaction {
             BehandlingsRepository(it).lagreBehandling(
+                fnr,
                 testVedtak.copy(stansOpphørVurdering = oppdaterte)
             )
         }


### PR DESCRIPTION
Det er i praksis ingen forskjell på `BehandlingIntern` og `BehandlingData`. Hovedforskjellen er at `DatadelingIntern` har en liste med fødselsnummer. Denne listen brukes kun for å lagre ned, så sender fødselsnummerene som eget prameter til `BehandlingsRepository::lagreBehandling`. Kunne beholdt fødselsnummerene, men ville krevd litt flere spørringer eller litt krumspring med spørringene.