### PR TITLE
Saml dsop-kode i dsop-pakke

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/Routes.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/Routes.kt
@@ -9,16 +9,45 @@ import com.papsign.ktor.openapigen.route.path.normal.post
 import com.papsign.ktor.openapigen.route.response.respond
 import com.papsign.ktor.openapigen.route.route
 import com.papsign.ktor.openapigen.route.tag
-import io.ktor.http.*
-import io.ktor.server.auth.*
-import io.ktor.server.auth.jwt.*
-import io.ktor.server.request.*
-import io.ktor.server.routing.*
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.withCharset
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
+import io.ktor.server.request.ApplicationRequest
+import io.ktor.server.request.path
+import io.ktor.server.routing.RoutingContext
+import java.time.Clock
+import java.time.LocalDate
+import java.util.*
+import javax.sql.DataSource
 import no.nav.aap.api.arena.ArenaService
-import no.nav.aap.api.intern.*
+import no.nav.aap.api.dsop.dsopRoutes
+import no.nav.aap.api.intern.InternVedtakRequestApiIntern
+import no.nav.aap.api.intern.Maksimum
+import no.nav.aap.api.intern.Medium
+import no.nav.aap.api.intern.MeldekortDetaljerRequest
+import no.nav.aap.api.intern.MeldekortDetaljerResponse
+import no.nav.aap.api.intern.PeriodeDTO
+import no.nav.aap.api.intern.PerioderInkludert11_17Response
+import no.nav.aap.api.intern.PerioderResponse
+import no.nav.aap.api.intern.PersonEksistererIAAPArena
+import no.nav.aap.api.intern.SakStatus
+import no.nav.aap.api.intern.SakStatusMeldekortbackend
+import no.nav.aap.api.intern.SignifikanteSakerResponse
+import no.nav.aap.api.intern.Vedtak
+import no.nav.aap.api.intern.VedtakUtenUtbetaling
+import no.nav.aap.api.kelvin.AktivitetsfaseService
+import no.nav.aap.api.kelvin.KelvinBehandlingStatus
 import no.nav.aap.api.kelvin.KelvinSakService
+import no.nav.aap.api.kelvin.KelvinSakStatus
+import no.nav.aap.api.kelvin.MeldekortService
+import no.nav.aap.api.kelvin.VedtakService
 import no.nav.aap.api.pdl.IPdlGateway
-import no.nav.aap.api.postgres.*
+import no.nav.aap.api.postgres.BehandlingsRepository
+import no.nav.aap.api.postgres.MeldekortPerioderRepository
+import no.nav.aap.api.postgres.SakStatusRepository
 import no.nav.aap.api.util.perioderMedAAp
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
@@ -32,17 +61,6 @@ import no.nav.aap.komponenter.type.Periode
 import no.nav.aap.tilgang.AuthorizationMachineToMachineConfig
 import no.nav.aap.tilgang.authorizedPost
 import org.slf4j.LoggerFactory
-import java.time.Clock
-import java.time.LocalDate
-import java.util.*
-import javax.sql.DataSource
-import no.nav.aap.api.kelvin.AktivitetsfaseService
-import no.nav.aap.api.kelvin.DsopService
-import no.nav.aap.api.kelvin.KelvinBehandlingStatus
-import no.nav.aap.api.kelvin.KelvinSakStatus
-import no.nav.aap.api.kelvin.MeldekortService
-import no.nav.aap.api.kelvin.VedtakService
-import no.nav.aap.api.kelvin.slåSammenMeldeperioder
 
 private val logger = LoggerFactory.getLogger("App")
 
@@ -459,76 +477,8 @@ fun NormalOpenAPIRoute.api(
     }
 
     tag(Tag.DSOP) {
-        route("/kelvin") {
-            route("/dsop") {
-                route("/vedtak").post<CallIdHeader, DsopResponse, DsopRequest>(
-                    info(
-                        description = """Henter ut vedtaksdata for en person for DSOP.
-                        Verdier som mangler er ikke tilgjengelige fra Kelvin.
-                    """.trimMargin(),
-                    )
-                ) { _, requestBody ->
-                    logger.info("Henter vedtak fra DSOP")
-                    Metrics.httpRequestTeller(pipeline.call)
-                    val utrekksperiode = Periode(requestBody.fomDato, requestBody.tomDato)
-
-                    sjekkTilgangTilPerson(requestBody.personIdent, token())
-
-                    val kelvinVedtak = dataSource.transaction { connection ->
-                        val dsopService = DsopService(connection)
-                        dsopService.hentDsopVedtak(
-                            requestBody.personIdent,
-                            utrekksperiode
-                        )
-                    }
-
-                    respond(
-                        DsopResponse(
-                            PeriodeDTO(utrekksperiode.fom, utrekksperiode.tom),
-                            kelvinVedtak
-                        )
-                    )
-                }
-                route("/meldekort").post<CallIdHeader, DsopMeldekortRespons, DsopRequest>(
-                    info(
-                        description = """Henter ut meldekort for bruker for DSOP API."""
-                    )
-                ) { _, requestBody ->
-                    Metrics.httpRequestTeller(pipeline.call)
-                    val utrekksperiode = Periode(requestBody.fomDato, requestBody.tomDato)
-
-                    sjekkTilgangTilPerson(requestBody.personIdent, token())
-
-                    val meldekortListe = dataSource.transaction { connection ->
-                        val meldekortService = MeldekortService(connection, pdlGateway, clock)
-                        meldekortService.hentAlleMeldekortMedRett(
-                            requestBody.personIdent,
-                            requestBody.fomDato,
-                            requestBody.tomDato
-                        )
-                            .map { meldekort ->
-                                DsopMeldekortDTO(
-                                    PeriodeDTO(meldekort.meldePeriode.fom, meldekort.meldePeriode.tom),
-                                    meldekort.arbeidPerDag.sumOf { it.timerArbeidet },
-                                    meldekort.arbeidPerDag.map {
-                                        DsopTimerArbeidetPerDagDTO(
-                                            it.dag,
-                                            it.timerArbeidet.toDouble()
-                                        )
-                                    },
-                                    meldekort.mottattTidspunkt
-                                )
-                            }.slåSammenMeldeperioder()
-                    }
-
-                    respond(
-                        DsopMeldekortRespons(
-                            PeriodeDTO(utrekksperiode.fom, utrekksperiode.tom),
-                            meldekortListe
-                        )
-                    )
-                }
-            }
+        route("/kelvin/dsop") {
+            dsopRoutes(dataSource, pdlGateway, clock)
         }
     }
 }
@@ -559,7 +509,7 @@ private fun tellKildesystem(
     }
 }
 
-private fun sjekkTilgangTilPerson(personIdent: String, token: OidcToken) {
+fun sjekkTilgangTilPerson(personIdent: String, token: OidcToken) {
     if (!token.isClientCredentials()) {
         Metrics.tokentype("m2m")
         val tilgang = TilgangGateway.harTilgangTilPerson(personIdent, token)
@@ -619,3 +569,5 @@ fun InternVedtakRequestApiIntern.tilKontrakt(): InternVedtakRequest {
 }
 
 class IngenTilgangException(message: String) : RuntimeException(message)
+
+val Periode.somDTO: PeriodeDTO get() = PeriodeDTO(fom, tom)

--- a/app/src/main/kotlin/no/nav/aap/api/dsop/DsopService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/dsop/DsopService.kt
@@ -1,14 +1,20 @@
-package no.nav.aap.api.kelvin
+package no.nav.aap.api.dsop
 
 import java.math.BigDecimal
+import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
 import no.nav.aap.api.intern.DsopMeldekortDTO
 import no.nav.aap.api.intern.DsopRettighetsTypeDTO
 import no.nav.aap.api.intern.DsopStatusDTO
+import no.nav.aap.api.intern.DsopTimerArbeidetPerDagDTO
 import no.nav.aap.api.intern.DsopVedtakDTO
 import no.nav.aap.api.intern.DsopVedtaksTypeDTO
 import no.nav.aap.api.intern.PeriodeDTO
+import no.nav.aap.api.kelvin.Meldekort
+import no.nav.aap.api.kelvin.MeldekortService
+import no.nav.aap.api.kelvin.RettighetsTypePeriode
+import no.nav.aap.api.pdl.IPdlGateway
 import no.nav.aap.api.postgres.BehandlingsRepository
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.tidslinje.somTidslinje
@@ -16,9 +22,15 @@ import no.nav.aap.komponenter.type.Periode
 
 class DsopService(
     private val behandlingsRepository: BehandlingsRepository,
+    private val meldekortService: MeldekortService,
 ) {
-    constructor(connection: DBConnection): this(
+    constructor(
+        connection: DBConnection,
+        pdlGateway: IPdlGateway,
+        clock: Clock = Clock.systemDefaultZone(),
+   ) : this(
         behandlingsRepository = BehandlingsRepository(connection),
+        meldekortService = MeldekortService(connection, pdlGateway, clock),
     )
 
     fun hentDsopVedtak(fnr: String, uttrekksperiode: Periode): List<DsopVedtakDTO> {
@@ -53,6 +65,54 @@ class DsopService(
                 }
         }
     }
+
+    fun hentDsopMeldekort(
+        personIdent: String,
+        periode: Periode,
+    ): List<DsopMeldekortDTO> {
+        return hentAlleMeldekortMedRett(personIdent, periode.fom, periode.tom)
+            .map { meldekort ->
+                DsopMeldekortDTO(
+                    PeriodeDTO(meldekort.meldePeriode.fom, meldekort.meldePeriode.tom),
+                    meldekort.arbeidPerDag.sumOf { it.timerArbeidet },
+                    meldekort.arbeidPerDag.map {
+                        DsopTimerArbeidetPerDagDTO(
+                            it.dag,
+                            it.timerArbeidet.toDouble()
+                        )
+                    },
+                    meldekort.mottattTidspunkt
+                )
+            }.slåSammenMeldeperioder()
+    }
+
+    private fun hentAlleMeldekortMedRett(
+        personIdentifikator: String,
+        fom: LocalDate,
+        tom: LocalDate
+    ): List<Meldekort> {
+        val kelvinVedtak = hentDsopVedtak(
+            personIdentifikator,
+            Periode(fom, tom)
+        )
+
+        val meldekortListe = meldekortService.hentAlleMeldekort(personIdentifikator, fom, tom)
+
+        val filtrerteMeldekort = meldekortListe.filter { meldekort ->
+            kelvinVedtak.any {
+                val periode = Periode(it.virkningsperiode.fom, it.virkningsperiode.tom)
+                periode.overlapper(
+                    Periode(
+                        meldekort.meldePeriode.fom,
+                        meldekort.meldePeriode.tom
+                    )
+                )
+            }
+        }
+
+        return filtrerteMeldekort
+    }
+
 }
 
 fun List<DsopMeldekortDTO>.slåSammenMeldeperioder(): List<DsopMeldekortDTO> {

--- a/app/src/main/kotlin/no/nav/aap/api/dsop/Route.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/dsop/Route.kt
@@ -1,0 +1,76 @@
+package no.nav.aap.api.dsop
+
+import com.papsign.ktor.openapigen.route.info
+import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
+import com.papsign.ktor.openapigen.route.path.normal.post
+import com.papsign.ktor.openapigen.route.response.respond
+import com.papsign.ktor.openapigen.route.route
+import java.time.Clock
+import javax.sql.DataSource
+import no.nav.aap.api.CallIdHeader
+import no.nav.aap.api.Metrics
+import no.nav.aap.api.intern.DsopMeldekortRespons
+import no.nav.aap.api.intern.DsopRequest
+import no.nav.aap.api.intern.DsopResponse
+import no.nav.aap.api.pdl.IPdlGateway
+import no.nav.aap.api.sjekkTilgangTilPerson
+import no.nav.aap.api.somDTO
+import no.nav.aap.komponenter.dbconnect.transaction
+import no.nav.aap.komponenter.server.auth.token
+import no.nav.aap.komponenter.type.Periode
+import org.slf4j.LoggerFactory
+
+fun NormalOpenAPIRoute.dsopRoutes(
+    dataSource: DataSource,
+    pdlGateway: IPdlGateway,
+    clock: Clock = Clock.systemDefaultZone(),
+) {
+    val logger = LoggerFactory.getLogger(javaClass)
+    route("/vedtak").post<CallIdHeader, DsopResponse, DsopRequest>(
+        info(
+            description = """Henter ut vedtaksdata for en person for DSOP.
+                        Verdier som mangler er ikke tilgjengelige fra Kelvin.
+                    """.trimMargin(),
+        )
+    ) { _, requestBody ->
+        logger.info("Henter vedtak fra DSOP")
+        Metrics.httpRequestTeller(pipeline.call)
+        val uttrekksperiode = Periode(requestBody.fomDato, requestBody.tomDato)
+
+        sjekkTilgangTilPerson(requestBody.personIdent, token())
+
+        val kelvinVedtak = dataSource.transaction { connection ->
+            val dsopService = DsopService(connection, pdlGateway, clock)
+            dsopService.hentDsopVedtak(requestBody.personIdent, uttrekksperiode)
+        }
+
+        respond(
+            DsopResponse(
+                uttrekksperiode.somDTO,
+                kelvinVedtak
+            )
+        )
+    }
+    route("/meldekort").post<CallIdHeader, DsopMeldekortRespons, DsopRequest>(
+        info(
+            description = """Henter ut meldekort for bruker for DSOP API."""
+        )
+    ) { _, requestBody ->
+        Metrics.httpRequestTeller(pipeline.call)
+        val uttrekksperiode = Periode(requestBody.fomDato, requestBody.tomDato)
+
+        sjekkTilgangTilPerson(requestBody.personIdent, token())
+
+        val meldekortListe = dataSource.transaction { connection ->
+            val dsopService = DsopService(connection, pdlGateway, clock)
+            dsopService.hentDsopMeldekort(requestBody.personIdent, uttrekksperiode)
+        }
+
+        respond(
+            DsopMeldekortRespons(
+                uttrekksperiode.somDTO,
+                meldekortListe
+            )
+        )
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/MeldekortService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/MeldekortService.kt
@@ -7,14 +7,12 @@ import no.nav.aap.api.pdl.IPdlGateway
 import no.nav.aap.api.postgres.BehandlingsRepository
 import no.nav.aap.api.postgres.MeldekortDetaljerRepository
 import no.nav.aap.komponenter.dbconnect.DBConnection
-import no.nav.aap.komponenter.type.Periode
 
 class MeldekortService(connection: DBConnection, val pdlGateway: IPdlGateway, clock: Clock) {
     val meldekortDetaljerRepository = MeldekortDetaljerRepository(connection)
     val vedtakService = VedtakService(BehandlingsRepository(connection), clock)
-    val dsopService = DsopService(connection)
 
-    private fun hentAlleMeldekort(
+    fun hentAlleMeldekort(
         personIdentifikator: String,
         fraDato: LocalDate? = null,
         tilDato: LocalDate? = null
@@ -42,33 +40,6 @@ class MeldekortService(connection: DBConnection, val pdlGateway: IPdlGateway, cl
             val vedtak = finnNyesteRelaterteVedtak(meldekort, personIdentifikator)
             Pair(meldekort, vedtak)
         }
-    }
-
-    fun hentAlleMeldekortMedRett(
-        personIdentifikator: String,
-        fom: LocalDate,
-        tom: LocalDate
-    ): List<Meldekort> {
-        val kelvinVedtak = dsopService.hentDsopVedtak(
-            personIdentifikator,
-            Periode(fom, tom)
-        )
-
-        val meldekortListe = hentAlleMeldekort(personIdentifikator, fom, tom)
-
-        val filtrerteMeldekort = meldekortListe.filter { meldekort ->
-            kelvinVedtak.any {
-                val periode = Periode(it.virkningsperiode.fom, it.virkningsperiode.tom)
-                periode.overlapper(
-                    Periode(
-                        meldekort.meldePeriode.fom,
-                        meldekort.meldePeriode.tom
-                    )
-                )
-            }
-        }
-
-        return filtrerteMeldekort
     }
 
 

--- a/app/src/test/kotlin/no/nav/aap/api/dsop/DsopServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/dsop/DsopServiceTest.kt
@@ -1,0 +1,194 @@
+package no.nav.aap.api.dsop
+
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+import no.nav.aap.api.intern.DsopMeldekortDTO
+import no.nav.aap.api.intern.DsopRettighetsTypeDTO
+import no.nav.aap.api.intern.DsopStatusDTO
+import no.nav.aap.api.intern.DsopTimerArbeidetPerDagDTO
+import no.nav.aap.api.intern.DsopVedtakDTO
+import no.nav.aap.api.intern.DsopVedtaksTypeDTO
+import no.nav.aap.api.intern.PeriodeDTO
+import no.nav.aap.api.kelvin.Behandling
+import no.nav.aap.api.kelvin.KelvinBehandlingStatus
+import no.nav.aap.api.kelvin.KelvinSakStatus
+import no.nav.aap.api.kelvin.RettighetsTypePeriode
+import no.nav.aap.api.kelvin.Sak
+import no.nav.aap.api.postgres.BehandlingsRepository
+import no.nav.aap.api.somDTO
+import no.nav.aap.api.util.PdlGatewayEmpty
+import no.nav.aap.behandlingsflyt.kontrakt.statistikk.RettighetsType
+import no.nav.aap.komponenter.dbconnect.transaction
+import no.nav.aap.komponenter.dbtest.TestDataSource
+import no.nav.aap.komponenter.type.Periode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DsopServiceTest {
+    private lateinit var dataSource: TestDataSource
+
+    @BeforeEach
+    fun setUp() {
+        dataSource = TestDataSource()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        dataSource.close()
+    }
+
+    private val fnr = listOf("123445")
+
+    private val testVedtak = Behandling(
+        underveisperiode = listOf(),
+        rettighetsperiode = Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 4, 1)),
+        behandlingStatus = KelvinBehandlingStatus.UTREDES,
+        behandlingsId = "123",
+        vedtaksDato = LocalDate.now(),
+        sak = Sak(
+            saksnummer = "ABCDE",
+            status = KelvinSakStatus.OPPRETTET,
+            opprettetTidspunkt = LocalDateTime.now()
+        ),
+        tilkjent = listOf(),
+        rettighetsTypeTidsLinje = listOf(
+            RettighetsTypePeriode(
+                LocalDate.of(2021, 1, 1),
+                LocalDate.of(2021, 2, 1),
+                RettighetsType.BISTANDSBEHOV.name
+            ),
+            RettighetsTypePeriode(
+                LocalDate.of(2021, 2, 2),
+                LocalDate.of(2021, 3, 1),
+                RettighetsType.SYKEPENGEERSTATNING.name
+            ),
+            RettighetsTypePeriode(
+                LocalDate.of(2021, 3, 2),
+                LocalDate.of(2021, 4, 1),
+                RettighetsType.SYKEPENGEERSTATNING.name
+            ),
+        ),
+        behandlingsReferanse = UUID.randomUUID().toString(),
+        samId = null,
+        vedtakId = 1234L,
+        beregningsgrunnlag = BigDecimal.ZERO,
+        nyttVedtak = false,
+        stansOpphørVurdering = emptySet(),
+    )
+
+    @Test
+    fun `lagre ned og hente ut dsop-vedtak, komprimerer like rettighetstypeperioder`() {
+        dataSource.transaction {
+            BehandlingsRepository(it).lagreBehandling(fnr, testVedtak)
+        }
+
+        val res = dataSource.transaction {
+            DsopService(it, PdlGatewayEmpty()).hentDsopVedtak(
+                "123445",
+                Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1))
+            )
+        }
+
+        assertThat(res)
+            .usingRecursiveComparison()
+            .isEqualTo(
+                listOf(
+                    DsopVedtakDTO(
+                        vedtakId = "1",
+                        vedtakStatus = DsopStatusDTO.AVSLUTTET,
+                        virkningsperiode = PeriodeDTO(
+                            LocalDate.of(2021, 1, 1),
+                            LocalDate.of(2021, 2, 1)
+                        ),
+                        rettighetsType = "AAP",
+                        utfall = "JA",
+                        aktivitetsfase = DsopRettighetsTypeDTO.BISTANDSBEHOV,
+                        vedtaksType = DsopVedtaksTypeDTO.E,
+                    ),
+                    DsopVedtakDTO(
+                        vedtakId = "1",
+                        vedtakStatus = DsopStatusDTO.AVSLUTTET,
+                        virkningsperiode = PeriodeDTO(
+                            LocalDate.of(2021, 2, 2),
+                            LocalDate.of(2021, 4, 1)
+                        ),
+                        rettighetsType = "AAP",
+                        utfall = "JA",
+                        aktivitetsfase = DsopRettighetsTypeDTO.SYKEPENGEERSTATNING,
+                        vedtaksType = DsopVedtaksTypeDTO.E,
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `slå sammen meldekort til ett`() {
+        val periode = Periode(LocalDate.of(2025, 4, 14), LocalDate.of(2025, 4, 16))
+        val meldekort = listOf(
+            DsopMeldekortDTO(
+                periode = periode.somDTO,
+                antallTimerArbeidet = BigDecimal.valueOf(10),
+                timerArbeidetPerDag = listOf(
+                    DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 14), 5.0),
+                    DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 15), 5.0)
+                ),
+                sistOppdatert = LocalDateTime.of(2025, 4, 17, 10, 0)
+            ),
+            DsopMeldekortDTO(
+                periode = periode.somDTO,
+                antallTimerArbeidet = BigDecimal.valueOf(5),
+                timerArbeidetPerDag = listOf(
+                    DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 15), 2.0),
+                    DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 16), 3.0)
+                ),
+                sistOppdatert = LocalDateTime.of(2025, 4, 18, 10, 0)
+            )
+        )
+
+        val res = meldekort.slåSammenMeldeperioder()
+
+        assertThat(res).hasSize(1)
+        val sammenslått = res.first()
+        assertThat(sammenslått.periode).isEqualTo(periode.somDTO)
+
+        // Meldekort nr 2 er korrigert. Så den 15de er det 2 timer arbeidet. 5+2+3=10
+        assertThat(sammenslått.timerArbeidetPerDag.sumOf { it.timerArbeidet }).isEqualByComparingTo(10.0)
+        assertThat(sammenslått.timerArbeidetPerDag).containsExactlyInAnyOrder(
+            DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 14), 5.0),
+            DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 15), 2.0),
+            DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 16), 3.0)
+        )
+        assertThat(sammenslått.sistOppdatert).isEqualTo(LocalDateTime.of(2025, 4, 18, 10, 0))
+    }
+
+    @Test
+    fun `slå sammen meldekort med ulike perioder`() {
+        val periode1 = Periode(LocalDate.of(2025, 4, 1), LocalDate.of(2025, 4, 5))
+        val periode2 = Periode(LocalDate.of(2025, 4, 6), LocalDate.of(2025, 4, 10))
+
+        val meldekort = listOf(
+            DsopMeldekortDTO(
+                periode = periode1.somDTO,
+                antallTimerArbeidet = BigDecimal.valueOf(5),
+                timerArbeidetPerDag = listOf(DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 1), 5.0)),
+                sistOppdatert = LocalDateTime.now()
+            ),
+            DsopMeldekortDTO(
+                periode = periode2.somDTO,
+                antallTimerArbeidet = BigDecimal.valueOf(10),
+                timerArbeidetPerDag = listOf(DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 6), 10.0)),
+                sistOppdatert = LocalDateTime.now()
+            )
+        )
+
+        val res = meldekort.slåSammenMeldeperioder()
+
+        assertThat(res).hasSize(2)
+        assertThat(res.map { it.periode }).containsExactlyInAnyOrder(periode1.somDTO, periode2.somDTO)
+    }
+
+}

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
@@ -5,13 +5,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
-import no.nav.aap.api.intern.DsopRettighetsTypeDTO
-import no.nav.aap.api.intern.DsopStatusDTO
-import no.nav.aap.api.intern.DsopVedtakDTO
-import no.nav.aap.api.intern.DsopVedtaksTypeDTO
-import no.nav.aap.api.intern.PeriodeDTO
 import no.nav.aap.api.kelvin.Behandling
-import no.nav.aap.api.kelvin.DsopService
 import no.nav.aap.api.kelvin.GjeldendeStansEllerOpphør
 import no.nav.aap.api.kelvin.KelvinBehandlingStatus
 import no.nav.aap.api.kelvin.KelvinSakStatus
@@ -92,51 +86,6 @@ class BehandlingsRepositoryTest {
         }
 
         assertThat(uthentetVedtak).hasSize(1)
-    }
-
-    @Test
-    fun `lagre ned og hente ut dsop-vedtak, komprimerer like rettighetstypeperioder`() {
-        dataSource.transaction {
-            BehandlingsRepository(it).lagreBehandling(fnr, testVedtak)
-        }
-
-        val res = dataSource.transaction {
-            DsopService(it).hentDsopVedtak(
-                "123445",
-                Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1))
-            )
-        }
-
-        assertThat(res)
-            .usingRecursiveComparison()
-            .isEqualTo(
-                listOf(
-                    DsopVedtakDTO(
-                        vedtakId = "1",
-                        vedtakStatus = DsopStatusDTO.AVSLUTTET,
-                        virkningsperiode = PeriodeDTO(
-                            LocalDate.of(2021, 1, 1),
-                            LocalDate.of(2021, 2, 1)
-                        ),
-                        rettighetsType = "AAP",
-                        utfall = "JA",
-                        aktivitetsfase = DsopRettighetsTypeDTO.BISTANDSBEHOV,
-                        vedtaksType = DsopVedtaksTypeDTO.E,
-                    ),
-                    DsopVedtakDTO(
-                        vedtakId = "1",
-                        vedtakStatus = DsopStatusDTO.AVSLUTTET,
-                        virkningsperiode = PeriodeDTO(
-                            LocalDate.of(2021, 2, 2),
-                            LocalDate.of(2021, 4, 1)
-                        ),
-                        rettighetsType = "AAP",
-                        utfall = "JA",
-                        aktivitetsfase = DsopRettighetsTypeDTO.SYKEPENGEERSTATNING,
-                        vedtaksType = DsopVedtaksTypeDTO.E,
-                    )
-                )
-            )
     }
 
     @Test

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/MeldekortDetaljerRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/MeldekortDetaljerRepositoryTest.kt
@@ -1,5 +1,8 @@
 package no.nav.aap.api.postgres
 
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
 import no.nav.aap.api.kelvin.Meldekort
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
@@ -8,13 +11,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import no.nav.aap.api.intern.DsopMeldekortDTO
-import no.nav.aap.api.intern.DsopTimerArbeidetPerDagDTO
-import no.nav.aap.api.intern.PeriodeDTO
-import no.nav.aap.api.kelvin.slåSammenMeldeperioder
 
 class MeldekortDetaljerRepositoryTest {
     private lateinit var dataSource: TestDataSource
@@ -75,73 +71,4 @@ class MeldekortDetaljerRepositoryTest {
                 BigDecimal::class.java)
             .isEqualTo(listOf(meldekort))
     }
-
-    @Test
-    fun `slå sammen meldekort til ett`() {
-        val periode = Periode(LocalDate.of(2025, 4, 14), LocalDate.of(2025, 4, 16))
-        val meldekort = listOf(
-            DsopMeldekortDTO(
-                periode = periode.somDTO,
-                antallTimerArbeidet = BigDecimal.valueOf(10),
-                timerArbeidetPerDag = listOf(
-                    DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 14), 5.0),
-                    DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 15), 5.0)
-                ),
-                sistOppdatert = LocalDateTime.of(2025, 4, 17, 10, 0)
-            ),
-            DsopMeldekortDTO(
-                periode = periode.somDTO,
-                antallTimerArbeidet = BigDecimal.valueOf(5),
-                timerArbeidetPerDag = listOf(
-                    DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 15), 2.0),
-                    DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 16), 3.0)
-                ),
-                sistOppdatert = LocalDateTime.of(2025, 4, 18, 10, 0)
-            )
-        )
-
-        val res = meldekort.slåSammenMeldeperioder()
-
-        assertThat(res).hasSize(1)
-        val sammenslått = res.first()
-        assertThat(sammenslått.periode).isEqualTo(periode.somDTO)
-
-        // Meldekort nr 2 er korrigert. Så den 15de er det 2 timer arbeidet. 5+2+3=10
-        assertThat(sammenslått.timerArbeidetPerDag.sumOf { it.timerArbeidet }).isEqualByComparingTo(10.0)
-        assertThat(sammenslått.timerArbeidetPerDag).containsExactlyInAnyOrder(
-            DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 14), 5.0),
-            DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 15), 2.0),
-            DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 16), 3.0)
-        )
-        assertThat(sammenslått.sistOppdatert).isEqualTo(LocalDateTime.of(2025, 4, 18, 10, 0))
-    }
-
-    @Test
-    fun `slå sammen meldekort med ulike perioder`() {
-        val periode1 = Periode(LocalDate.of(2025, 4, 1), LocalDate.of(2025, 4, 5))
-        val periode2 = Periode(LocalDate.of(2025, 4, 6), LocalDate.of(2025, 4, 10))
-
-        val meldekort = listOf(
-            DsopMeldekortDTO(
-                periode = periode1.somDTO,
-                antallTimerArbeidet = BigDecimal.valueOf(5),
-                timerArbeidetPerDag = listOf(DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 1), 5.0)),
-                sistOppdatert = LocalDateTime.now()
-            ),
-            DsopMeldekortDTO(
-                periode = periode2.somDTO,
-                antallTimerArbeidet = BigDecimal.valueOf(10),
-                timerArbeidetPerDag = listOf(DsopTimerArbeidetPerDagDTO(LocalDate.of(2025, 4, 6), 10.0)),
-                sistOppdatert = LocalDateTime.now()
-            )
-        )
-
-        val res = meldekort.slåSammenMeldeperioder()
-
-        assertThat(res).hasSize(2)
-        assertThat(res.map { it.periode }).containsExactlyInAnyOrder(periode1.somDTO, periode2.somDTO)
-    }
-
 }
-
-private val Periode.somDTO get() = PeriodeDTO(fom, tom)


### PR DESCRIPTION
Samler dsop-kode i dsop-pakken:
- `MeldekortService::hentAlleMeldekortMedRett` brukes kun av dsop-endepunkt og er avhengig av `DsopService`, så flytter den inn i `DsopService`.
- Flytter unit-tester som testet `DsopService` til `DsopServiceTest`
- Flytter dsop-routes inn i pakken.