### PR TITLE
Fjern behandlingId, da den ikke (burde) brukes

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/dsop/DsopService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/dsop/DsopService.kt
@@ -41,7 +41,7 @@ class DsopService(
                 .map { (periode, verdi) -> RettighetsTypePeriode(periode.fom, periode.tom, verdi) }
                 .map { rettighetsTypePeriode ->
                     DsopVedtakDTO(
-                        vedtakId = it.behandlingsId,
+                        vedtakId = it.vedtakId.toString(),
                         vedtakStatus = when (rettighetsTypePeriode.tom >= LocalDate.now()) {
                             true -> DsopStatusDTO.LØPENDE
                             else -> DsopStatusDTO.AVSLUTTET

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
@@ -9,7 +9,6 @@ import no.nav.aap.komponenter.tidslinje.somTidslinje
 import no.nav.aap.komponenter.type.Periode
 
 data class Behandling(
-    val behandlingsId: String,
     val behandlingsReferanse: String,
     @Deprecated("Ikke del denne utad.")
     val rettighetsperiode: Periode,

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
@@ -9,7 +9,6 @@ fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): Behandling {
         underveisperiode = this.underveisperiode.map { it.tilDomene() },
         rettighetsperiode = Periode(this.rettighetsPeriodeFom, this.rettighetsPeriodeTom),
         behandlingStatus = this.behandlingStatus.tilDomene(),
-        behandlingsId = this.behandlingsId,
         vedtaksDato = this.vedtaksDato,
         sak = this.sak.tilDomene(),
         tilkjent = this.tilkjent.map { it.tilDomene() },

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
@@ -286,7 +286,6 @@ class BehandlingsRepository(private val connection: DBConnection) {
             val behandlinger = hentBehandlinger(sak.id)
             behandlinger.map { behandling ->
                 Behandling(
-                    behandlingsId = behandling.id.toString(),
                     behandlingsReferanse = behandling.behandlingReferanse,
                     underveisperiode = hentUnderveis(behandling.id),
                     behandlingStatus = behandling.behandlingStatus,

--- a/app/src/test/kotlin/no/nav/aap/api/dsop/DsopServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/dsop/DsopServiceTest.kt
@@ -47,7 +47,6 @@ class DsopServiceTest {
         underveisperiode = listOf(),
         rettighetsperiode = Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 4, 1)),
         behandlingStatus = KelvinBehandlingStatus.UTREDES,
-        behandlingsId = "123",
         vedtaksDato = LocalDate.now(),
         sak = Sak(
             saksnummer = "ABCDE",
@@ -98,7 +97,7 @@ class DsopServiceTest {
             .isEqualTo(
                 listOf(
                     DsopVedtakDTO(
-                        vedtakId = "1",
+                        vedtakId = "1234",
                         vedtakStatus = DsopStatusDTO.AVSLUTTET,
                         virkningsperiode = PeriodeDTO(
                             LocalDate.of(2021, 1, 1),
@@ -110,7 +109,7 @@ class DsopServiceTest {
                         vedtaksType = DsopVedtaksTypeDTO.E,
                     ),
                     DsopVedtakDTO(
-                        vedtakId = "1",
+                        vedtakId = "1234",
                         vedtakStatus = DsopStatusDTO.AVSLUTTET,
                         virkningsperiode = PeriodeDTO(
                             LocalDate.of(2021, 2, 2),

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
@@ -39,7 +39,6 @@ class BehandlingsRepositoryTest {
         underveisperiode = listOf(),
         rettighetsperiode = Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2022, 4, 1)),
         behandlingStatus = KelvinBehandlingStatus.UTREDES,
-        behandlingsId = "123",
         vedtaksDato = LocalDate.now(),
         sak = Sak(
             saksnummer = "ABCDE",


### PR DESCRIPTION
En "breaking change" er at dsop-vedtak returnerte `Behandling::behandlingsId` som `vedtakId` i `DsopVedtakDTO`, men returnerer med denne PRen `Behandling::vedtakId`.

`Behandling::behandlingsId` er `id`-kolonnen fra `behandlinger`-tabellen. Den har ingen sammenheng med `behandlingId` fra behandlingsflyt. Det er en syntetisk nøkkel lokal til `api-intern`.

Det gir spesielt lite mening å returnere behandlingid når https://github.com/navikt/aap-api-intern/pull/728 merges, for da vil det noen ganger returneres behandlingId og andre ganger vedtakId.