### PR TITLE
Erstatt liste med TilkjentPeriode med tidslinje

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
@@ -1,9 +1,11 @@
 package no.nav.aap.api.kelvin
 
 import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.math.roundToInt
 import no.nav.aap.komponenter.tidslinje.Tidslinje
 import no.nav.aap.komponenter.tidslinje.somTidslinje
 import no.nav.aap.komponenter.type.Periode
@@ -16,7 +18,7 @@ data class Behandling(
     val behandlingStatus: KelvinBehandlingStatus,
     val vedtaksDato: LocalDate,
     val sak: Sak,
-    val tilkjent: List<TilkjentPeriode>,
+    val tilkjent: Tidslinje<TilkjentYtelse>,
     val rettighetsTypePerioder: List<RettighetsTypePeriode>,
     val samId: String?,
     val vedtakId: Long,
@@ -85,21 +87,29 @@ data class Sak(
 )
 
 /**
- * @param samordningUføregradering Svarer til prosent uføre. 100% bør medføre 0% gradering.
+ * @param samordningUføregradering Svarer til prosent uføre.
  */
-data class TilkjentPeriode(
-    val tilkjentFom: LocalDate,
-    val tilkjentTom: LocalDate,
+data class TilkjentYtelse(
     val dagsats: Int,
     val gradering: Int,
-    val samordningUføregradering: Int? = null,
+    val samordningUføregradering: Int?,
     val grunnlagsfaktor: BigDecimal,
     val grunnbeløp: BigDecimal,
     val antallBarn: Int,
     val barnetilleggsats: BigDecimal,
-    val barnetillegg: BigDecimal
-)
+    val barnetillegg: BigDecimal,
+) {
+    fun gradertBarnetillegg(): BigDecimal =
+        this.barnetillegg.multiply(
+            this.gradering.toBigDecimal()
+                .divide(100.toBigDecimal())
+        ).setScale(0, RoundingMode.HALF_UP)
 
+    fun regnUtDagsatsEtterUføreReduksjon(): Int =
+        this.dagsats.times(
+            (100 - (this.samordningUføregradering ?: 0)) / 100.0
+        ).roundToInt()
+}
 data class UnderveisIntern(
     val underveisFom: LocalDate,
     val underveisTom: LocalDate,
@@ -126,5 +136,4 @@ enum class KelvinBehandlingStatus {
 
     fun iverksatt() =
         this == IVERKSETTES || this == AVSLUTTET
-
 }

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/KontraktOversetter.kt
@@ -1,7 +1,14 @@
 package no.nav.aap.api.kelvin
 
 import no.nav.aap.behandlingsflyt.kontrakt.behandling.Status
-import no.nav.aap.behandlingsflyt.kontrakt.datadeling.*
+import no.nav.aap.behandlingsflyt.kontrakt.datadeling.ArbeidIPeriodeDTO
+import no.nav.aap.behandlingsflyt.kontrakt.datadeling.DatadelingDTO
+import no.nav.aap.behandlingsflyt.kontrakt.datadeling.DetaljertMeldekortDTO
+import no.nav.aap.behandlingsflyt.kontrakt.datadeling.SakDTO
+import no.nav.aap.behandlingsflyt.kontrakt.datadeling.StansEllerOpphørEnumDTO
+import no.nav.aap.behandlingsflyt.kontrakt.datadeling.TilkjentDTO
+import no.nav.aap.behandlingsflyt.kontrakt.datadeling.UnderveisDTO
+import no.nav.aap.komponenter.tidslinje.somTidslinje
 import no.nav.aap.komponenter.type.Periode
 
 fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): Behandling {
@@ -11,7 +18,7 @@ fun DatadelingDTO.tilDomene(nyttVedtak: Boolean = false): Behandling {
         behandlingStatus = this.behandlingStatus.tilDomene(),
         vedtaksDato = this.vedtaksDato,
         sak = this.sak.tilDomene(),
-        tilkjent = this.tilkjent.map { it.tilDomene() },
+        tilkjent = this.tilkjent.somTidslinje({ Periode(it.tilkjentFom, it.tilkjentTom) }, { it.tilDomene() }),
         rettighetsTypePerioder = this.rettighetsTypeTidsLinje.map { it.tilDomene() },
         behandlingsReferanse = this.behandlingsReferanse,
         samId = this.samId,
@@ -61,10 +68,8 @@ fun Status.tilDomene(): KelvinBehandlingStatus {
     }
 }
 
-fun TilkjentDTO.tilDomene(): TilkjentPeriode {
-    return TilkjentPeriode(
-        tilkjentFom = this.tilkjentFom,
-        tilkjentTom = this.tilkjentTom,
+fun TilkjentDTO.tilDomene(): TilkjentYtelse {
+    return TilkjentYtelse(
         dagsats = this.dagsats,
         gradering = this.gradering,
         samordningUføregradering = this.samordningUføregradering,

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
@@ -1,6 +1,9 @@
 package no.nav.aap.api.kelvin
 
+import com.papsign.ktor.openapigen.annotations.properties.description.Description
+import java.math.BigDecimal
 import java.time.Clock
+import java.time.DayOfWeek
 import java.time.LocalDate
 import no.nav.aap.api.intern.Kilde
 import no.nav.aap.api.intern.Maksimum
@@ -9,14 +12,10 @@ import no.nav.aap.api.intern.UtbetalingMedMer
 import no.nav.aap.api.intern.Vedtak
 import no.nav.aap.api.intern.VedtakUtenUtbetaling
 import no.nav.aap.api.postgres.BehandlingsRepository
-import no.nav.aap.api.postgres.TilkjentDB
-import no.nav.aap.api.postgres.VedtakUtenUtbetalingUtenPeriode
-import no.nav.aap.api.postgres.weekdaysBetween
 import no.nav.aap.api.utledVedtakStatus
 import no.nav.aap.behandlingsflyt.kontrakt.sak.Status
 import no.nav.aap.komponenter.tidslinje.JoinStyle
 import no.nav.aap.komponenter.tidslinje.Segment
-import no.nav.aap.komponenter.tidslinje.Tidslinje
 import no.nav.aap.komponenter.type.Periode
 
 class VedtakService(
@@ -26,26 +25,8 @@ class VedtakService(
     fun hentMaksimum(fnr: String, interval: Periode): Maksimum {
         val kelvinData = behandlingsRepository.hentVedtaksData(fnr, interval)
         val vedtak = kelvinData.flatMap { behandling ->
-            val tilkjent = Tidslinje(
-                behandling.tilkjent.map {
-                    Segment(
-                        Periode(it.tilkjentFom, it.tilkjentTom),
-                        TilkjentDB(
-                            dagsats = it.dagsats,
-                            gradering = it.gradering,
-                            grunnlagsfaktor = it.grunnlagsfaktor,
-                            grunnbeløp = it.grunnbeløp,
-                            antallBarn = it.antallBarn,
-                            barnetilleggsats = it.barnetilleggsats,
-                            barnetillegg = it.barnetillegg,
-                            uføregrad = it.samordningUføregradering
-                        )
-                    )
-                }
-            )
-
             val perioderTidslinje = behandling.rettighetsTypeTidslinje.kombiner(
-                tilkjent,
+                behandling.tilkjent,
                 JoinStyle.LEFT_JOIN { periode, left, right ->
                     Segment(
                         periode,
@@ -73,7 +54,7 @@ class VedtakService(
                 }
             ).komprimer()
             val tilkjentPerioder =
-                tilkjent.splittOppIPerioder(perioderTidslinje.perioder().toList())
+                behandling.tilkjent.splittOppIPerioder(perioderTidslinje.perioder().toList())
 
             perioderTidslinje.kombiner(
                 tilkjentPerioder,
@@ -144,26 +125,8 @@ class VedtakService(
     ): Medium {
         val kelvinData = behandlingsRepository.hentVedtaksData(fnr, periode)
         val vedtak: List<VedtakUtenUtbetaling> = kelvinData.flatMap { behandling ->
-            val tilkjent = Tidslinje(
-                behandling.tilkjent.map {
-                    Segment(
-                        Periode(it.tilkjentFom, it.tilkjentTom),
-                        TilkjentDB(
-                            it.dagsats,
-                            it.gradering,
-                            it.grunnlagsfaktor,
-                            it.grunnbeløp,
-                            it.antallBarn,
-                            it.barnetilleggsats,
-                            it.barnetillegg,
-                            it.samordningUføregradering
-                        )
-                    )
-                }
-            )
-
             behandling.rettighetsTypeTidslinje.kombiner(
-                tilkjent,
+                behandling.tilkjent,
                 JoinStyle.LEFT_JOIN { periode, left, right ->
                     Segment(
                         periode,
@@ -203,5 +166,64 @@ class VedtakService(
         }
 
         return Medium(vedtak)
+    }
+}
+
+fun weekdaysBetween(startDate: LocalDate, endDate: LocalDate): Int {
+    var count = 0
+    var date = startDate
+
+    while (!date.isAfter(endDate)) {
+        if (date.dayOfWeek != DayOfWeek.SATURDAY && date.dayOfWeek != DayOfWeek.SUNDAY) {
+            count++
+        }
+        date = date.plusDays(1)
+    }
+
+    return count
+}
+
+/**
+ * @param vedtakId Svarer til ID til vedtak-tabellen i behandlingsflyt.
+ */
+data class VedtakUtenUtbetalingUtenPeriode(
+    val vedtakId: String,
+    @param:Description("Full dagsats før reduksjoner.")
+    val dagsats: Int,
+    @param:Description("Dagsats etter uføre-reduksjon. Dette er lik dagsats * (100 - uføregrad) / 100. Kommer kun fra nytt system (Kelvin). Ved manglende data er denne null.")
+    val dagsatsEtterUføreReduksjon: Int,
+    @param:Description("Status på et vedtak. Mulige verdier er LØPENDE, AVSLUTTET, UTREDES.")
+    val status: String, //Hypotese, vedtaksstatuskode
+    val saksnummer: String,
+    val vedtaksdato: LocalDate, //reg_dato
+    @param:Description("Rettighetsgruppe. For data fra Arena er dette aktivitetsfasekode.")
+    val rettighetsType: String, ////aktivitetsfase //Aktfasekode
+    val beregningsgrunnlag: Int,
+    val barnMedStonad: Int,
+    @param:Description("Kildesystem for vedtak. Mulige verdier er ARENA og KELVIN.")
+    val kildesystem: Kilde,
+    val samordningsId: String? = null,
+    val opphorsAarsak: String? = null,
+    val barnetilleggSats: BigDecimal? = null,
+) {
+    fun tilVedtakUtenUtbetaling(periode: no.nav.aap.api.intern.Periode): VedtakUtenUtbetaling {
+        return VedtakUtenUtbetaling(
+            vedtakId = this.vedtakId,
+            dagsats = this.dagsats,
+            dagsatsEtterUføreReduksjon = this.dagsatsEtterUføreReduksjon,
+            status = this.status,
+            saksnummer = this.saksnummer,
+            vedtaksdato = this.vedtaksdato,
+            vedtaksTypeKode = null,
+            vedtaksTypeNavn = null,
+            periode = periode,
+            rettighetsType = this.rettighetsType,
+            beregningsgrunnlag = this.beregningsgrunnlag,
+            barnMedStonad = this.barnMedStonad,
+            barnetillegg = barnMedStonad * (this.barnetilleggSats?.toInt() ?: 0),
+            kildesystem = this.kildesystem,
+            samordningsId = this.samordningsId,
+            opphorsAarsak = this.opphorsAarsak
+        )
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/postgres/BehandlingsRepository.kt
@@ -1,14 +1,8 @@
 package no.nav.aap.api.postgres
 
-import com.papsign.ktor.openapigen.annotations.properties.description.Description
 import java.math.BigDecimal
-import java.math.RoundingMode
-import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
-import kotlin.math.roundToInt
-import no.nav.aap.api.intern.Kilde
-import no.nav.aap.api.intern.VedtakUtenUtbetaling
 import no.nav.aap.api.kelvin.Avslagsårsak
 import no.nav.aap.api.kelvin.Behandling
 import no.nav.aap.api.kelvin.GjeldendeStansEllerOpphør
@@ -17,9 +11,11 @@ import no.nav.aap.api.kelvin.KelvinSakStatus
 import no.nav.aap.api.kelvin.RettighetsTypePeriode
 import no.nav.aap.api.kelvin.Sak
 import no.nav.aap.api.kelvin.StansEllerOpphør
-import no.nav.aap.api.kelvin.TilkjentPeriode
+import no.nav.aap.api.kelvin.TilkjentYtelse
 import no.nav.aap.api.kelvin.UnderveisIntern
 import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.tidslinje.Segment
+import no.nav.aap.komponenter.tidslinje.Tidslinje
 import no.nav.aap.komponenter.type.Periode
 import org.slf4j.LoggerFactory
 
@@ -212,19 +208,19 @@ class BehandlingsRepository(private val connection: DBConnection) {
                                               BARNETILLEGG, UFOREGRADERING)
                 VALUES (?, ?::daterange, ?, ?, ?, ?, ?, ?, ?, ?)
             """.trimIndent(),
-            behandling.tilkjent
+            behandling.tilkjent.segmenter()
         ) {
             setParams {
                 setLong(1, nytilkjentId)
-                setPeriode(2, Periode(it.tilkjentFom, it.tilkjentTom))
-                setBigDecimal(3, it.dagsats.toBigDecimal())
-                setInt(4, it.gradering)
-                setBigDecimal(5, it.grunnlagsfaktor)
-                setBigDecimal(6, it.grunnbeløp)
-                setInt(7, it.antallBarn)
-                setBigDecimal(8, it.barnetilleggsats)
-                setBigDecimal(9, it.barnetillegg)
-                setInt(10, it.samordningUføregradering)
+                setPeriode(2, it.periode)
+                setBigDecimal(3, it.verdi.dagsats.toBigDecimal())
+                setInt(4, it.verdi.gradering)
+                setBigDecimal(5, it.verdi.grunnlagsfaktor)
+                setBigDecimal(6, it.verdi.grunnbeløp)
+                setInt(7, it.verdi.antallBarn)
+                setBigDecimal(8, it.verdi.barnetilleggsats)
+                setBigDecimal(9, it.verdi.barnetillegg)
+                setInt(10, it.verdi.samordningUføregradering)
             }
         }
         if (behandling.beregningsgrunnlag != null) {
@@ -417,7 +413,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
         }.toSet()
     }
 
-    private fun hentAvslagsårsaker(stansOpphørVurderingId: Long): Set<Avslagsårsak>{
+    private fun hentAvslagsårsaker(stansOpphørVurderingId: Long): Set<Avslagsårsak> {
         return connection.queryList(
             """SELECT * FROM avslagsarsak WHERE stans_opphor_vurdering_id = ?""".trimIndent()
         ){
@@ -430,7 +426,7 @@ class BehandlingsRepository(private val connection: DBConnection) {
         }.toSet()
     }
 
-    private fun hentTilkjentYtelse(behandlingId: Long): List<TilkjentPeriode> {
+    private fun hentTilkjentYtelse(behandlingId: Long): Tidslinje<TilkjentYtelse> {
         return connection.queryList(
             """
                 SELECT * FROM TILKJENT_PERIODE
@@ -442,20 +438,21 @@ class BehandlingsRepository(private val connection: DBConnection) {
         ) {
             setParams { setLong(1, behandlingId) }
             setRowMapper {
-                TilkjentPeriode(
-                    tilkjentFom = it.getPeriode("PERIODE").fom,
-                    tilkjentTom = it.getPeriode("PERIODE").tom,
-                    dagsats = it.getBigDecimal("DAGSATS").toInt(),
-                    gradering = it.getInt("GRADERING"),
-                    grunnlagsfaktor = it.getBigDecimal("GRUNNLAGSFAKTOR"),
-                    grunnbeløp = it.getBigDecimal("GRUNNBELOP"),
-                    antallBarn = it.getInt("ANTALL_BARN"),
-                    barnetilleggsats = it.getBigDecimal("BARNETILLEGGSATS"),
-                    barnetillegg = it.getBigDecimal("BARNETILLEGG"),
-                    samordningUføregradering = it.getIntOrNull("UFOREGRADERING")
+                Segment(
+                    it.getPeriode("PERIODE"),
+                    TilkjentYtelse(
+                        dagsats = it.getBigDecimal("DAGSATS").toInt(),
+                        gradering = it.getInt("GRADERING"),
+                        grunnlagsfaktor = it.getBigDecimal("GRUNNLAGSFAKTOR"),
+                        grunnbeløp = it.getBigDecimal("GRUNNBELOP"),
+                        antallBarn = it.getInt("ANTALL_BARN"),
+                        barnetilleggsats = it.getBigDecimal("BARNETILLEGGSATS"),
+                        barnetillegg = it.getBigDecimal("BARNETILLEGG"),
+                        samordningUføregradering = it.getIntOrNull("UFOREGRADERING")
+                    )
                 )
             }
-        }
+        }.let { Tidslinje(it) }
     }
 
     fun erNyttVedtak(fnr: String): Boolean {
@@ -517,87 +514,3 @@ data class BehandlingDB(
     val vedtakId: Long? = null,
     val førstegangsbehandling: Boolean
 )
-
-/**
- * @param uføregrad Svarer til prosent uføre.
- */
-data class TilkjentDB(
-    val dagsats: Int,
-    val gradering: Int,
-    val grunnlagsfaktor: BigDecimal,
-    val grunnbeløp: BigDecimal,
-    val antallBarn: Int,
-    val barnetilleggsats: BigDecimal,
-    val barnetillegg: BigDecimal,
-    val uføregrad: Int? = 0,
-) {
-    fun gradertBarnetillegg(): BigDecimal =
-        this.barnetillegg.multiply(
-            this.gradering.toBigDecimal()
-                .divide(100.toBigDecimal())
-        ).setScale(0, RoundingMode.HALF_UP)
-
-    fun regnUtDagsatsEtterUføreReduksjon(): Int =
-        this.dagsats.times(
-            (100 - (this.uføregrad ?: 0)) / 100.0
-        ).roundToInt()
-}
-
-fun weekdaysBetween(startDate: LocalDate, endDate: LocalDate): Int {
-    var count = 0
-    var date = startDate
-
-    while (!date.isAfter(endDate)) {
-        if (date.dayOfWeek != DayOfWeek.SATURDAY && date.dayOfWeek != DayOfWeek.SUNDAY) {
-            count++
-        }
-        date = date.plusDays(1)
-    }
-
-    return count
-}
-
-/**
- * @param vedtakId Svarer til ID til vedtak-tabellen i behandlingsflyt.
- */
-data class VedtakUtenUtbetalingUtenPeriode(
-    val vedtakId: String,
-    @param:Description("Full dagsats før reduksjoner.")
-    val dagsats: Int,
-    @param:Description("Dagsats etter uføre-reduksjon. Dette er lik dagsats * (100 - uføregrad) / 100. Kommer kun fra nytt system (Kelvin). Ved manglende data er denne null.")
-    val dagsatsEtterUføreReduksjon: Int,
-    @param:Description("Status på et vedtak. Mulige verdier er LØPENDE, AVSLUTTET, UTREDES.")
-    val status: String, //Hypotese, vedtaksstatuskode
-    val saksnummer: String,
-    val vedtaksdato: LocalDate, //reg_dato
-    @param:Description("Rettighetsgruppe. For data fra Arena er dette aktivitetsfasekode.")
-    val rettighetsType: String, ////aktivitetsfase //Aktfasekode
-    val beregningsgrunnlag: Int,
-    val barnMedStonad: Int,
-    @param:Description("Kildesystem for vedtak. Mulige verdier er ARENA og KELVIN.")
-    val kildesystem: Kilde,
-    val samordningsId: String? = null,
-    val opphorsAarsak: String? = null,
-    val barnetilleggSats: BigDecimal? = null,
-) {
-    fun tilVedtakUtenUtbetaling(periode: no.nav.aap.api.intern.Periode): VedtakUtenUtbetaling {
-        return VedtakUtenUtbetaling(
-            vedtakId = this.vedtakId,
-            dagsats = this.dagsats,
-            dagsatsEtterUføreReduksjon = this.dagsatsEtterUføreReduksjon,
-            status = this.status,
-            saksnummer = this.saksnummer,
-            vedtaksdato = this.vedtaksdato,
-            vedtaksTypeKode = null,
-            vedtaksTypeNavn = null,
-            periode = periode,
-            rettighetsType = this.rettighetsType,
-            beregningsgrunnlag = this.beregningsgrunnlag,
-            barnMedStonad = this.barnMedStonad,
-            barnetillegg = barnMedStonad * (this.barnetilleggSats?.toInt() ?: 0),
-            kildesystem = this.kildesystem,
-            samordningsId = this.samordningsId,
-            opphorsAarsak = this.opphorsAarsak
-        )
-    }
-}

--- a/app/src/test/kotlin/no/nav/aap/api/dsop/DsopServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/dsop/DsopServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.aap.api.util.PdlGatewayEmpty
 import no.nav.aap.behandlingsflyt.kontrakt.statistikk.RettighetsType
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
+import no.nav.aap.komponenter.tidslinje.tidslinjeOf
 import no.nav.aap.komponenter.type.Periode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -53,7 +54,7 @@ class DsopServiceTest {
             status = KelvinSakStatus.OPPRETTET,
             opprettetTidspunkt = LocalDateTime.now()
         ),
-        tilkjent = listOf(),
+        tilkjent = tidslinjeOf(),
         rettighetsTypePerioder = listOf(
             RettighetsTypePeriode(
                 LocalDate.of(2021, 1, 1),

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
@@ -15,6 +15,7 @@ import no.nav.aap.api.kelvin.StansEllerOpphør
 import no.nav.aap.behandlingsflyt.kontrakt.statistikk.RettighetsType
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
+import no.nav.aap.komponenter.tidslinje.tidslinjeOf
 import no.nav.aap.komponenter.type.Periode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -45,7 +46,7 @@ class BehandlingsRepositoryTest {
             status = KelvinSakStatus.OPPRETTET,
             opprettetTidspunkt = LocalDateTime.now()
         ),
-        tilkjent = listOf(),
+        tilkjent = tidslinjeOf(),
         rettighetsTypePerioder = listOf(
             RettighetsTypePeriode(
                 LocalDate.of(2021, 1, 1),

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/TilkjentYtelseTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/TilkjentYtelseTest.kt
@@ -1,12 +1,13 @@
 package no.nav.aap.api.postgres
 
+import no.nav.aap.api.kelvin.TilkjentYtelse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class TilkjentDBTest {
+class TilkjentYtelseTest {
     @Test
     fun `gradering etter uføre`() {
-        val tilkjent = TilkjentDB(
+        val tilkjent = TilkjentYtelse(
             dagsats = 1000,
             gradering = 50,
             grunnlagsfaktor = 2.4.toBigDecimal(),
@@ -14,7 +15,7 @@ class TilkjentDBTest {
             antallBarn = 0,
             barnetilleggsats = 37.toBigDecimal(),
             barnetillegg = 0.toBigDecimal(),
-            uføregrad = 30
+            samordningUføregradering = 30
         )
 
         val dagsatsEtterUføreReduksjon = tilkjent.regnUtDagsatsEtterUføreReduksjon()


### PR DESCRIPTION
- Merger `TilkjentPeriode` og `TilkjentDB` til `TilkjentYtelse` og lagrer som tidslinje rett på `Behandling`.
- Flytter `weekdaysBetween` og `VedtakUtenUtbetalingUtenPeriode` ut av `BehandlingsRepository` og inn i `VedtakService` hvor de faktisk brukes