### PR TITLE
Fix barnetilleg + bokumenter barnetillegg-felter

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
@@ -99,11 +99,42 @@ data class TilkjentYtelse(
     val samordningUføregradering: Int?,
     val grunnlagsfaktor: BigDecimal,
     val grunnbeløp: BigDecimal,
+
+    /** Antall barn som gir rett til barnetillegg. */
     val antallBarn: Int,
+
+    /** Størrelsen på ugradert barnetilleggsats.
+     *
+     * Verdien er ugradert, i den forstand at:
+     * Hvis barnetilleggsatsen er spesifisert i AAP-forskriften § 8 til 38 kroner, og medlemmet får 50% AAP,
+     * så vil [barnetilleggsats] være 38.
+     **/
     val barnetilleggsats: BigDecimal,
+
+    /** Størrelsen på total, ugradert barnetillegg.
+     *
+     * Verdien er total i den forstand at den tar hensyn til antall barn.
+     *
+     * Den er ugradert i den forstand at hvis medlemmet har 2 barn, får 75 % AAP
+     * på grunn av samordning, og barnetilleggssatsen er spesifisert i AAP-forskriften § 8 til 38 kroner,
+     * så vil [barnetillegg] være 2 * 38 = 76 kroner. Altså vi har ikke redusert barnetillegget med 25% her.
+     *
+     * Spesifikasjon: [barnetillegg] = [barnetilleggsats] * [antallBarn].
+     */
     val barnetillegg: BigDecimal,
 ) {
+
+    /** Størrelsen på total, gradert barnetillegg.
+     *
+     * Verdien er total i den forstand at den tar hensyn til antall barn.
+     *
+     * Den er gradert i den forstand at hvis medlemmet har 2 barn, får 75 % AAP
+     * på grunn av samordning, og barnetilleggssatsen er spesifisert i AAP-forskriften § 8 til 38 kroner,
+     * så vil [gradertBarnetillegg] gi 2 * 38 * 0.75 = 57 kroner. I motsetning til [barnetillegg] som ikke
+     * tar hensyn til gradering, og dermed gir 76 kroner.
+     */
     fun gradertBarnetillegg(): BigDecimal =
+        /* TODO: denne utregningen burde flyttes til behandlingsflyt. Ønsker ikke at vi f.eks. får forskjellig avrunding i vedtaket og dette API-et.  */
         this.barnetillegg.multiply(
             this.gradering.toBigDecimal()
                 .divide(100.toBigDecimal())

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
@@ -206,7 +206,7 @@ data class VedtakUtenUtbetalingUtenPeriode(
             rettighetsType = this.rettighetsType,
             beregningsgrunnlag = this.beregningsgrunnlag,
             barnMedStonad = this.barnMedStonad,
-            barnetillegg = barnMedStonad * (this.barnetilleggSats?.toInt() ?: 0),
+            barnetillegg = this.barnetilleggSats?.toInt() ?: 0,
             kildesystem = this.kildesystem,
             samordningsId = this.samordningsId,
             opphorsAarsak = this.opphorsAarsak

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
@@ -1,16 +1,21 @@
 package no.nav.aap.api.kelvin
 
 import com.papsign.ktor.openapigen.annotations.properties.description.Description
-import no.nav.aap.api.intern.*
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.DayOfWeek
+import java.time.LocalDate
+import no.nav.aap.api.intern.Kilde
+import no.nav.aap.api.intern.Maksimum
+import no.nav.aap.api.intern.Medium
+import no.nav.aap.api.intern.UtbetalingMedMer
+import no.nav.aap.api.intern.Vedtak
+import no.nav.aap.api.intern.VedtakUtenUtbetaling
 import no.nav.aap.api.postgres.BehandlingsRepository
 import no.nav.aap.behandlingsflyt.kontrakt.sak.Status
 import no.nav.aap.komponenter.tidslinje.JoinStyle
 import no.nav.aap.komponenter.tidslinje.Segment
 import no.nav.aap.komponenter.type.Periode
-import java.math.BigDecimal
-import java.time.Clock
-import java.time.DayOfWeek
-import java.time.LocalDate
 
 class VedtakService(
     private val behandlingsRepository: BehandlingsRepository,
@@ -87,8 +92,6 @@ class VedtakService(
                                         utbetaling.periode.tom
                                     ),
                                     dagsats = utbetaling.verdi.dagsats * utbetaling.verdi.gradering / 100,
-                                    barnetilegg = utbetaling.verdi.gradertBarnetillegg()
-                                        .toInt(),
                                     barnetillegg = utbetaling.verdi.gradertBarnetillegg()
                                         .toInt()
                                 )
@@ -134,7 +137,7 @@ class VedtakService(
                             kildesystem = Kilde.KELVIN,
                             samordningsId = behandling.samId,
                             opphorsAarsak = null,
-                            barnetilleggSats = right?.verdi?.gradertBarnetillegg(),
+                            barnetilleggSats = right?.verdi?.barnetilleggsats,
                         )
                     )
                 }
@@ -185,11 +188,29 @@ data class VedtakUtenUtbetalingUtenPeriode(
     @param:Description("Rettighetsgruppe. For data fra Arena er dette aktivitetsfasekode.")
     val rettighetsType: String, ////aktivitetsfase //Aktfasekode
     val beregningsgrunnlag: Int,
+
+    @param:Description("Antall barn som gir rett til barnetillegg.")
+    /** Antall barn som gir rett til barnetillegg.  */
     val barnMedStonad: Int,
+
     @param:Description("Kildesystem for vedtak. Mulige verdier er ARENA og KELVIN.")
     val kildesystem: Kilde,
     val samordningsId: String? = null,
     val opphorsAarsak: String? = null,
+
+    @param:Description("""
+     Størrelsen på ugradert barnetilleggsats.
+    
+    Verdien er ugradert, i den forstand at:
+    Hvis barnetilleggsatsen er spesifisert i AAP-forskriften § 8 til 38 kroner, og medlemmet får 50% AAP,
+    så vil [barnetilleggSats] være 38.
+    """)
+    /** Størrelsen på ugradert barnetilleggsats.
+     *
+     * Verdien er ugradert, i den forstand at:
+     * Hvis barnetilleggsatsen er spesifisert i AAP-forskriften § 8 til 38 kroner, og medlemmet får 50% AAP,
+     * så vil [barnetilleggSats] være 38.
+     **/
     val barnetilleggSats: BigDecimal? = null,
 ) {
     fun tilVedtakUtenUtbetaling(periode: no.nav.aap.api.intern.Periode): VedtakUtenUtbetaling {
@@ -206,7 +227,7 @@ data class VedtakUtenUtbetalingUtenPeriode(
             rettighetsType = this.rettighetsType,
             beregningsgrunnlag = this.beregningsgrunnlag,
             barnMedStonad = this.barnMedStonad,
-            barnetillegg = this.barnetilleggSats?.toInt() ?: 0,
+            barnetillegg = barnMedStonad * (this.barnetilleggSats?.toInt() ?: 0),
             kildesystem = this.kildesystem,
             samordningsId = this.samordningsId,
             opphorsAarsak = this.opphorsAarsak

--- a/app/src/main/kotlin/no/nav/aap/api/util/HjelpeFunctions.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/util/HjelpeFunctions.kt
@@ -31,7 +31,7 @@ fun no.nav.aap.arenaoppslag.kontrakt.modeller.Vedtak.fraKontrakt(): Vedtak {
         utbetaling = this.utbetaling.map { it.fraKontrakt() },
         kildesystem = Kilde.ARENA,
         barnetillegg = this.utbetaling.lastOrNull()?.barnetillegg ?: 0,
-        barnetilleggSats = (this.utbetaling.lastOrNull()?.barnetillegg ?: 0) / this.barnMedStonad,
+        barnetilleggSats = 0, // Hva skal dette være? Kanskje (this.utbetaling.lastOrNull()?.barnetillegg ?: 0) / this.barnMedStonad,
         samordningsId = null,
         opphorsAarsak = null
     )
@@ -99,7 +99,6 @@ fun no.nav.aap.arenaoppslag.kontrakt.modeller.UtbetalingMedMer.fraKontrakt(): Ut
         this.belop,
         this.dagsats,
         this.barnetillegg,
-        this.barnetillegg
     )
 }
 

--- a/app/src/main/kotlin/no/nav/aap/api/util/HjelpeFunctions.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/util/HjelpeFunctions.kt
@@ -30,7 +30,10 @@ fun no.nav.aap.arenaoppslag.kontrakt.modeller.Vedtak.fraKontrakt(): Vedtak {
         vedtaksTypeNavn = this.vedtaksTypeNavn,
         utbetaling = this.utbetaling.map { it.fraKontrakt() },
         kildesystem = Kilde.ARENA,
-        barnetillegg = this.utbetaling.lastOrNull()?.barnetillegg ?: 0
+        barnetillegg = this.utbetaling.lastOrNull()?.barnetillegg ?: 0,
+        barnetilleggSats = (this.utbetaling.lastOrNull()?.barnetillegg ?: 0) / this.barnMedStonad,
+        samordningsId = null,
+        opphorsAarsak = null
     )
 }
 

--- a/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
@@ -220,7 +220,10 @@ class BehandlingsDataTest : PostgresTestBase() {
             }
 
             assertEquals(HttpStatusCode.OK, maksimumResponseM2m.status)
-            assertEquals(3, maksimumResponseM2m.body<Maksimum>().vedtak.size)
+            val response = maksimumResponseM2m.body<Maksimum>()
+            assertEquals(3, response.vedtak.size)
+            assertThat(response.vedtak.first().barnetillegg).isEqualTo(72)
+            assertThat(response.vedtak.first().utbetaling.first().barnetillegg).isEqualTo(72)
         }
     }
 
@@ -461,7 +464,7 @@ class BehandlingsDataTest : PostgresTestBase() {
     }
 
     @Test
-    fun `ekte data kopiert fra behandlingsflyt, snapshot-test`() {
+    fun `snapshot - maksimum`() {
         // Oppdater json-filene ved endring
         val config = TestConfig.default()
         val azure = AzureTokenGen("test", "test")
@@ -480,7 +483,9 @@ class BehandlingsDataTest : PostgresTestBase() {
                     modiaProducer = fakes.kafka,
                     // Setter nå-tidspunkt i framtiden for å kunne få utbetalinger
                     clock = Clock.fixed(
-                        Instant.from(LocalDate.of(2025, 12, 13).atStartOfDay().toInstant(ZoneOffset.UTC)),
+                        Instant.from(
+                            LocalDate.of(2025, 12, 13).atStartOfDay().toInstant(ZoneOffset.UTC)
+                        ),
                         ZoneId.of("UTC")
                     )
                 )
@@ -512,7 +517,7 @@ class BehandlingsDataTest : PostgresTestBase() {
             assertThat(uthentetFraApi.vedtak).hasSize(2)
 
             val forventetResultatFraResources =
-                javaClass.getResource("/forstegangsvedtak_fra_api.json")!!.readText()
+                javaClass.getResource("/forstegangsvedtak_fra_maksimum.json")!!.readText()
             val forventet = DefaultJsonMapper.fromJson<Maksimum>(forventetResultatFraResources)
 
             println(DefaultJsonMapper.toJson(uthentetFraApi))
@@ -521,6 +526,137 @@ class BehandlingsDataTest : PostgresTestBase() {
             assertThat(uthentetFraApi).usingRecursiveComparison().isEqualTo(forventet)
         }
     }
+
+
+    @Test
+    fun `snapshot - maksimum uten utbetaling`() {
+        // Oppdater json-filene ved endring
+        val config = TestConfig.default()
+        val azure = AzureTokenGen("test", "test")
+
+        val testfil =
+            javaClass.getResource("/forstegangsvedtak_fra_behandlingsflyt.json")!!.readText()
+        val testData = DefaultJsonMapper.fromJson<DatadelingDTO>(testfil)
+
+
+        testApplication {
+            application {
+                api(
+                    config = config,
+                    datasource = dataSource,
+                    arenaService = fakes.arenaService,
+                    modiaProducer = fakes.kafka,
+                    // Setter nå-tidspunkt i framtiden for å kunne få utbetalinger
+                    clock = Clock.fixed(
+                        Instant.from(
+                            LocalDate.of(2025, 12, 13).atStartOfDay().toInstant(ZoneOffset.UTC)
+                        ),
+                        ZoneId.of("UTC")
+                    )
+                )
+            }
+
+            jsonHttpClient.post("/api/insert/vedtak") {
+                bearerAuth(azure.generate(isApp = true))
+                contentType(ContentType.Application.Json)
+                setBody(
+                    testData
+                )
+            }
+
+            val maksimumRespons = jsonHttpClient.post("/maksimumUtenUtbetaling") {
+                bearerAuth(azure.generate(isApp = true))
+                contentType(ContentType.Application.Json)
+                setBody(
+                    InternVedtakRequest(
+                        "01410026747",
+                        LocalDate.now().minusYears(0),
+                        LocalDate.now().plusMonths(1)
+                    )
+                )
+            }
+            assertThat(maksimumRespons.status).isEqualTo(HttpStatusCode.OK)
+
+            val uthentetFraApi = maksimumRespons.body<Medium>()
+            println(DefaultJsonMapper.toJson(uthentetFraApi))
+            assertThat(uthentetFraApi.vedtak).hasSize(2)
+
+            val forventetResultatFraResources =
+                javaClass.getResource("/forstegangsvedtak_fra_medium.json")!!.readText()
+            val forventet = DefaultJsonMapper.fromJson<Medium>(forventetResultatFraResources)
+
+            println(DefaultJsonMapper.toJson(uthentetFraApi))
+
+
+            assertThat(uthentetFraApi).usingRecursiveComparison().isEqualTo(forventet)
+        }
+    }
+
+
+    @Test
+    fun `snapshot - kelvin maksimum uten utbetaling`() {
+        // Oppdater json-filene ved endring
+        val config = TestConfig.default()
+        val azure = AzureTokenGen("test", "test")
+
+        val testfil =
+            javaClass.getResource("/forstegangsvedtak_fra_behandlingsflyt.json")!!.readText()
+        val testData = DefaultJsonMapper.fromJson<DatadelingDTO>(testfil)
+
+
+        testApplication {
+            application {
+                api(
+                    config = config,
+                    datasource = dataSource,
+                    arenaService = fakes.arenaService,
+                    modiaProducer = fakes.kafka,
+                    // Setter nå-tidspunkt i framtiden for å kunne få utbetalinger
+                    clock = Clock.fixed(
+                        Instant.from(
+                            LocalDate.of(2025, 12, 13).atStartOfDay().toInstant(ZoneOffset.UTC)
+                        ),
+                        ZoneId.of("UTC")
+                    )
+                )
+            }
+
+            jsonHttpClient.post("/api/insert/vedtak") {
+                bearerAuth(azure.generate(isApp = true))
+                contentType(ContentType.Application.Json)
+                setBody(
+                    testData
+                )
+            }
+
+            val maksimumRespons = jsonHttpClient.post("/kelvin/maksimumUtenUtbetaling") {
+                bearerAuth(azure.generate(isApp = true))
+                contentType(ContentType.Application.Json)
+                setBody(
+                    InternVedtakRequest(
+                        "01410026747",
+                        LocalDate.now().minusYears(0),
+                        LocalDate.now().plusMonths(1)
+                    )
+                )
+            }
+            assertThat(maksimumRespons.status).isEqualTo(HttpStatusCode.OK)
+
+            val uthentetFraApi = maksimumRespons.body<Medium>()
+            println(DefaultJsonMapper.toJson(uthentetFraApi))
+            assertThat(uthentetFraApi.vedtak).hasSize(2)
+
+            val forventetResultatFraResources =
+                javaClass.getResource("/forstegangsvedtak_fra_medium.json")!!.readText()
+            val forventet = DefaultJsonMapper.fromJson<Medium>(forventetResultatFraResources)
+
+            println(DefaultJsonMapper.toJson(uthentetFraApi))
+
+
+            assertThat(uthentetFraApi).usingRecursiveComparison().isEqualTo(forventet)
+        }
+    }
+
 
 
     private val ApplicationTestBuilder.jsonHttpClient: HttpClient

--- a/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
@@ -464,137 +464,27 @@ class BehandlingsDataTest : PostgresTestBase() {
     }
 
     @Test
-    fun `snapshot - maksimum`() {
-        // Oppdater json-filene ved endring
-        val config = TestConfig.default()
-        val azure = AzureTokenGen("test", "test")
-
-        val testfil =
-            javaClass.getResource("/forstegangsvedtak_fra_behandlingsflyt.json")!!.readText()
-        val testData = DefaultJsonMapper.fromJson<DatadelingDTO>(testfil)
-
-
-        testApplication {
-            application {
-                api(
-                    config = config,
-                    datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    // Setter nå-tidspunkt i framtiden for å kunne få utbetalinger
-                    clock = Clock.fixed(
-                        Instant.from(
-                            LocalDate.of(2025, 12, 13).atStartOfDay().toInstant(ZoneOffset.UTC)
-                        ),
-                        ZoneId.of("UTC")
-                    )
-                )
-            }
-
-            jsonHttpClient.post("/api/insert/vedtak") {
-                bearerAuth(azure.generate(isApp = true))
-                contentType(ContentType.Application.Json)
-                setBody(
-                    testData
-                )
-            }
-
-            val maksimumRespons = jsonHttpClient.post("/maksimum") {
-                bearerAuth(azure.generate(isApp = true))
-                contentType(ContentType.Application.Json)
-                setBody(
-                    InternVedtakRequest(
-                        "01410026747",
-                        LocalDate.now().minusYears(0),
-                        LocalDate.now().plusMonths(1)
-                    )
-                )
-            }
-            assertThat(maksimumRespons.status).isEqualTo(HttpStatusCode.OK)
-
-            val uthentetFraApi = maksimumRespons.body<Maksimum>()
-            println(DefaultJsonMapper.toJson(uthentetFraApi))
-            assertThat(uthentetFraApi.vedtak).hasSize(2)
-
-            val forventetResultatFraResources =
-                javaClass.getResource("/forstegangsvedtak_fra_maksimum.json")!!.readText()
-            val forventet = DefaultJsonMapper.fromJson<Maksimum>(forventetResultatFraResources)
-
-            println(DefaultJsonMapper.toJson(uthentetFraApi))
-
-
-            assertThat(uthentetFraApi).usingRecursiveComparison().isEqualTo(forventet)
-        }
-    }
-
+    fun `snapshot - maksimum`() = snapshotTest<Maksimum>(
+        endpoint = "/maksimum",
+        forventetResourceFil = "/forstegangsvedtak_fra_maksimum.json",
+    )
 
     @Test
-    fun `snapshot - maksimum uten utbetaling`() {
-        // Oppdater json-filene ved endring
-        val config = TestConfig.default()
-        val azure = AzureTokenGen("test", "test")
-
-        val testfil =
-            javaClass.getResource("/forstegangsvedtak_fra_behandlingsflyt.json")!!.readText()
-        val testData = DefaultJsonMapper.fromJson<DatadelingDTO>(testfil)
-
-
-        testApplication {
-            application {
-                api(
-                    config = config,
-                    datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    // Setter nå-tidspunkt i framtiden for å kunne få utbetalinger
-                    clock = Clock.fixed(
-                        Instant.from(
-                            LocalDate.of(2025, 12, 13).atStartOfDay().toInstant(ZoneOffset.UTC)
-                        ),
-                        ZoneId.of("UTC")
-                    )
-                )
-            }
-
-            jsonHttpClient.post("/api/insert/vedtak") {
-                bearerAuth(azure.generate(isApp = true))
-                contentType(ContentType.Application.Json)
-                setBody(
-                    testData
-                )
-            }
-
-            val maksimumRespons = jsonHttpClient.post("/maksimumUtenUtbetaling") {
-                bearerAuth(azure.generate(isApp = true))
-                contentType(ContentType.Application.Json)
-                setBody(
-                    InternVedtakRequest(
-                        "01410026747",
-                        LocalDate.now().minusYears(0),
-                        LocalDate.now().plusMonths(1)
-                    )
-                )
-            }
-            assertThat(maksimumRespons.status).isEqualTo(HttpStatusCode.OK)
-
-            val uthentetFraApi = maksimumRespons.body<Medium>()
-            println(DefaultJsonMapper.toJson(uthentetFraApi))
-            assertThat(uthentetFraApi.vedtak).hasSize(2)
-
-            val forventetResultatFraResources =
-                javaClass.getResource("/forstegangsvedtak_fra_medium.json")!!.readText()
-            val forventet = DefaultJsonMapper.fromJson<Medium>(forventetResultatFraResources)
-
-            println(DefaultJsonMapper.toJson(uthentetFraApi))
-
-
-            assertThat(uthentetFraApi).usingRecursiveComparison().isEqualTo(forventet)
-        }
-    }
-
+    fun `snapshot - maksimum uten utbetaling`() = snapshotTest<Medium>(
+        endpoint = "/maksimumUtenUtbetaling",
+        forventetResourceFil = "/forstegangsvedtak_fra_medium.json",
+    )
 
     @Test
-    fun `snapshot - kelvin maksimum uten utbetaling`() {
+    fun `snapshot - kelvin maksimum uten utbetaling`() = snapshotTest<Medium>(
+        endpoint = "/kelvin/maksimumUtenUtbetaling",
+        forventetResourceFil = "/forstegangsvedtak_fra_medium.json",
+    )
+
+    private inline fun <reified T : Any> snapshotTest(
+        endpoint: String,
+        forventetResourceFil: String,
+    ) {
         // Oppdater json-filene ved endring
         val config = TestConfig.default()
         val azure = AzureTokenGen("test", "test")
@@ -602,7 +492,6 @@ class BehandlingsDataTest : PostgresTestBase() {
         val testfil =
             javaClass.getResource("/forstegangsvedtak_fra_behandlingsflyt.json")!!.readText()
         val testData = DefaultJsonMapper.fromJson<DatadelingDTO>(testfil)
-
 
         testApplication {
             application {
@@ -624,12 +513,10 @@ class BehandlingsDataTest : PostgresTestBase() {
             jsonHttpClient.post("/api/insert/vedtak") {
                 bearerAuth(azure.generate(isApp = true))
                 contentType(ContentType.Application.Json)
-                setBody(
-                    testData
-                )
+                setBody(testData)
             }
 
-            val maksimumRespons = jsonHttpClient.post("/kelvin/maksimumUtenUtbetaling") {
+            val maksimumRespons = jsonHttpClient.post(endpoint) {
                 bearerAuth(azure.generate(isApp = true))
                 contentType(ContentType.Application.Json)
                 setBody(
@@ -642,16 +529,12 @@ class BehandlingsDataTest : PostgresTestBase() {
             }
             assertThat(maksimumRespons.status).isEqualTo(HttpStatusCode.OK)
 
-            val uthentetFraApi = maksimumRespons.body<Medium>()
+            val uthentetFraApi = maksimumRespons.body<T>()
             println(DefaultJsonMapper.toJson(uthentetFraApi))
-            assertThat(uthentetFraApi.vedtak).hasSize(2)
 
             val forventetResultatFraResources =
-                javaClass.getResource("/forstegangsvedtak_fra_medium.json")!!.readText()
-            val forventet = DefaultJsonMapper.fromJson<Medium>(forventetResultatFraResources)
-
-            println(DefaultJsonMapper.toJson(uthentetFraApi))
-
+                javaClass.getResource(forventetResourceFil)!!.readText()
+            val forventet = DefaultJsonMapper.fromJson<T>(forventetResultatFraResources)
 
             assertThat(uthentetFraApi).usingRecursiveComparison().isEqualTo(forventet)
         }

--- a/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
@@ -430,7 +430,7 @@ class BehandlingsDataTest : PostgresTestBase() {
             }
             assertThat(mediumResponseM2m.status).isEqualTo(HttpStatusCode.OK)
             val body = mediumResponseM2m.body<Medium>()
-            assertThat(body.vedtak).hasSize(4)
+            assertThat(body.vedtak).hasSize(3)
 
             val mediumResponseObo = jsonHttpClient.post("/maksimumUtenUtbetaling") {
                 bearerAuth(OidcToken(azure.generate(isApp = false)).token())

--- a/app/src/test/resources/forstegangsvedtak_fra_behandlingsflyt.json
+++ b/app/src/test/resources/forstegangsvedtak_fra_behandlingsflyt.json
@@ -1,258 +1,4 @@
 {
-  "underveisperiode": [
-    {
-      "underveisFom": "2025-11-19",
-      "underveisTom": "2025-11-30",
-      "meldeperiodeFom": "2025-11-17",
-      "meldeperiodeTom": "2025-11-30",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "SYKEPENGEERSTATNING",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2025-12-01",
-      "underveisTom": "2025-12-14",
-      "meldeperiodeFom": "2025-12-01",
-      "meldeperiodeTom": "2025-12-14",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "SYKEPENGEERSTATNING",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2025-12-15",
-      "underveisTom": "2025-12-28",
-      "meldeperiodeFom": "2025-12-15",
-      "meldeperiodeTom": "2025-12-28",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "SYKEPENGEERSTATNING",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2025-12-29",
-      "underveisTom": "2025-12-31",
-      "meldeperiodeFom": "2025-12-29",
-      "meldeperiodeTom": "2026-01-11",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "SYKEPENGEERSTATNING",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-01-01",
-      "underveisTom": "2026-01-11",
-      "meldeperiodeFom": "2025-12-29",
-      "meldeperiodeTom": "2026-01-11",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-01-12",
-      "underveisTom": "2026-01-25",
-      "meldeperiodeFom": "2026-01-12",
-      "meldeperiodeTom": "2026-01-25",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-01-26",
-      "underveisTom": "2026-02-08",
-      "meldeperiodeFom": "2026-01-26",
-      "meldeperiodeTom": "2026-02-08",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-02-09",
-      "underveisTom": "2026-02-22",
-      "meldeperiodeFom": "2026-02-09",
-      "meldeperiodeTom": "2026-02-22",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-02-23",
-      "underveisTom": "2026-03-08",
-      "meldeperiodeFom": "2026-02-23",
-      "meldeperiodeTom": "2026-03-08",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-03-09",
-      "underveisTom": "2026-03-22",
-      "meldeperiodeFom": "2026-03-09",
-      "meldeperiodeTom": "2026-03-22",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-03-23",
-      "underveisTom": "2026-04-05",
-      "meldeperiodeFom": "2026-03-23",
-      "meldeperiodeTom": "2026-04-05",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-04-06",
-      "underveisTom": "2026-04-19",
-      "meldeperiodeFom": "2026-04-06",
-      "meldeperiodeTom": "2026-04-19",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-04-20",
-      "underveisTom": "2026-05-03",
-      "meldeperiodeFom": "2026-04-20",
-      "meldeperiodeTom": "2026-05-03",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-05-04",
-      "underveisTom": "2026-05-17",
-      "meldeperiodeFom": "2026-05-04",
-      "meldeperiodeTom": "2026-05-17",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-05-18",
-      "underveisTom": "2026-05-31",
-      "meldeperiodeFom": "2026-05-18",
-      "meldeperiodeTom": "2026-05-31",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-06-01",
-      "underveisTom": "2026-06-14",
-      "meldeperiodeFom": "2026-06-01",
-      "meldeperiodeTom": "2026-06-14",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-06-15",
-      "underveisTom": "2026-06-28",
-      "meldeperiodeFom": "2026-06-15",
-      "meldeperiodeTom": "2026-06-28",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-06-29",
-      "underveisTom": "2026-07-12",
-      "meldeperiodeFom": "2026-06-29",
-      "meldeperiodeTom": "2026-07-12",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-07-13",
-      "underveisTom": "2026-07-26",
-      "meldeperiodeFom": "2026-07-13",
-      "meldeperiodeTom": "2026-07-26",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-07-27",
-      "underveisTom": "2026-08-09",
-      "meldeperiodeFom": "2026-07-27",
-      "meldeperiodeTom": "2026-08-09",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-08-10",
-      "underveisTom": "2026-08-23",
-      "meldeperiodeFom": "2026-08-10",
-      "meldeperiodeTom": "2026-08-23",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-08-24",
-      "underveisTom": "2026-09-06",
-      "meldeperiodeFom": "2026-08-24",
-      "meldeperiodeTom": "2026-09-06",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-09-07",
-      "underveisTom": "2026-09-20",
-      "meldeperiodeFom": "2026-09-07",
-      "meldeperiodeTom": "2026-09-20",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-09-21",
-      "underveisTom": "2026-10-04",
-      "meldeperiodeFom": "2026-09-21",
-      "meldeperiodeTom": "2026-10-04",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-10-05",
-      "underveisTom": "2026-10-18",
-      "meldeperiodeFom": "2026-10-05",
-      "meldeperiodeTom": "2026-10-18",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-10-19",
-      "underveisTom": "2026-11-01",
-      "meldeperiodeFom": "2026-10-19",
-      "meldeperiodeTom": "2026-11-01",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-11-02",
-      "underveisTom": "2026-11-15",
-      "meldeperiodeFom": "2026-11-02",
-      "meldeperiodeTom": "2026-11-15",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    },
-    {
-      "underveisFom": "2026-11-16",
-      "underveisTom": "2026-11-18",
-      "meldeperiodeFom": "2026-11-16",
-      "meldeperiodeTom": "2026-11-29",
-      "utfall": "OPPFYLT",
-      "rettighetsType": "BISTANDSBEHOV",
-      "avslagsårsak": null
-    }
-  ],
   "rettighetsPeriodeFom": "2025-11-19",
   "rettighetsPeriodeTom": "2026-11-18",
   "behandlingStatus": "IVERKSETTES",
@@ -276,9 +22,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2025-12-01",
@@ -289,9 +35,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2025-12-15",
@@ -302,9 +48,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2025-12-29",
@@ -315,9 +61,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-01-01",
@@ -328,9 +74,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-01-12",
@@ -341,9 +87,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-01-26",
@@ -354,9 +100,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-02-09",
@@ -367,9 +113,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-02-23",
@@ -380,9 +126,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-03-09",
@@ -393,9 +139,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-03-23",
@@ -406,9 +152,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-04-06",
@@ -419,9 +165,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-04-20",
@@ -432,9 +178,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-05-04",
@@ -445,9 +191,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-05-18",
@@ -458,9 +204,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-06-01",
@@ -471,9 +217,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-06-15",
@@ -484,9 +230,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-06-29",
@@ -497,9 +243,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-07-13",
@@ -510,9 +256,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-07-27",
@@ -523,9 +269,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-08-10",
@@ -536,9 +282,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-08-24",
@@ -549,9 +295,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-09-07",
@@ -562,9 +308,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-09-21",
@@ -575,9 +321,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-10-05",
@@ -588,9 +334,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-10-19",
@@ -601,9 +347,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-11-02",
@@ -614,9 +360,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     },
     {
       "tilkjentFom": "2026-11-16",
@@ -627,9 +373,9 @@
       "grunnlag": 1022.00,
       "grunnlagsfaktor": 0.0078500000,
       "grunnbeløp": 130160.00,
-      "antallBarn": 0,
-      "barnetilleggsats": 0.00,
-      "barnetillegg": 0.00
+      "antallBarn": 2,
+      "barnetilleggsats": 38.00,
+      "barnetillegg": 76.00
     }
   ],
   "rettighetsTypeTidsLinje": [

--- a/app/src/test/resources/forstegangsvedtak_fra_maksimum.json
+++ b/app/src/test/resources/forstegangsvedtak_fra_maksimum.json
@@ -1,0 +1,63 @@
+{
+  "vedtak": [
+    {
+      "dagsats": 1022,
+      "dagsatsEtterUføreReduksjon": 1022,
+      "vedtakId": "2",
+      "status": "LØPENDE",
+      "saksnummer": "4LDQPDS",
+      "vedtaksdato": "2025-11-19",
+      "periode": {
+        "fraOgMedDato": "2025-11-19",
+        "tilOgMedDato": "2025-12-31"
+      },
+      "rettighetsType": "SYKEPENGEERSTATNING",
+      "beregningsgrunnlag": 212984,
+      "barnMedStonad": 2,
+      "barnetillegg": 76,
+      "barnetilleggSats": 38,
+      "kildesystem": "KELVIN",
+      "samordningsId": null,
+      "opphorsAarsak": null,
+      "vedtaksTypeKode": null,
+      "vedtaksTypeNavn": null,
+      "utbetaling": [
+        {
+          "reduksjon": null,
+          "utbetalingsgrad": 100,
+          "periode": {
+            "fraOgMedDato": "2025-11-19",
+            "tilOgMedDato": "2025-11-30"
+          },
+          "belop": 8784,
+          "dagsats": 1022,
+          "barnetilegg": 76,
+          "barnetillegg": 76
+        }
+      ]
+    },
+    {
+      "dagsats": 1022,
+      "dagsatsEtterUføreReduksjon": 1022,
+      "vedtakId": "2",
+      "status": "LØPENDE",
+      "saksnummer": "4LDQPDS",
+      "vedtaksdato": "2025-11-19",
+      "periode": {
+        "fraOgMedDato": "2026-01-01",
+        "tilOgMedDato": "2026-11-18"
+      },
+      "rettighetsType": "BISTANDSBEHOV",
+      "beregningsgrunnlag": 212984,
+      "barnMedStonad": 2,
+      "barnetillegg": 76,
+      "barnetilleggSats": 38,
+      "kildesystem": "KELVIN",
+      "samordningsId": null,
+      "opphorsAarsak": null,
+      "vedtaksTypeKode": null,
+      "vedtaksTypeNavn": null,
+      "utbetaling": []
+    }
+  ]
+}

--- a/app/src/test/resources/forstegangsvedtak_fra_medium.json
+++ b/app/src/test/resources/forstegangsvedtak_fra_medium.json
@@ -13,27 +13,14 @@
       },
       "rettighetsType": "SYKEPENGEERSTATNING",
       "beregningsgrunnlag": 212984,
-      "barnMedStonad": 0,
-      "barnetillegg": 0,
+      "barnMedStonad": 2,
+      "barnetillegg": 76,
+      "barnetilleggSats": 38,
       "kildesystem": "KELVIN",
       "samordningsId": null,
       "opphorsAarsak": null,
       "vedtaksTypeKode": null,
-      "vedtaksTypeNavn": null,
-      "utbetaling": [
-        {
-          "reduksjon": null,
-          "utbetalingsgrad": 100,
-          "periode": {
-            "fraOgMedDato": "2025-11-19",
-            "tilOgMedDato": "2025-11-30"
-          },
-          "belop": 8176,
-          "dagsats": 1022,
-          "barnetilegg": 0,
-          "barnetillegg": 0
-        }
-      ]
+      "vedtaksTypeNavn": null
     },
     {
       "dagsats": 1022,
@@ -48,14 +35,14 @@
       },
       "rettighetsType": "BISTANDSBEHOV",
       "beregningsgrunnlag": 212984,
-      "barnMedStonad": 0,
-      "barnetillegg": 0,
+      "barnMedStonad": 2,
+      "barnetillegg": 76,
+      "barnetilleggSats": 38,
       "kildesystem": "KELVIN",
       "samordningsId": null,
       "opphorsAarsak": null,
       "vedtaksTypeKode": null,
-      "vedtaksTypeNavn": null,
-      "utbetaling": []
+      "vedtaksTypeNavn": null
     }
   ]
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 ktor = "3.4.3"
 komponenter = "2.0.51"
 tilgang = "1.0.202"
-behandlingsflyt = "0.0.597"
+behandlingsflyt = "0.0.598"
 oppgave = "0.0.170"
 arenaoppslag = "0.5.2"
 resilience4j = "2.4.0"

--- a/kontrakt/src/main/kotlin/Maksimum.kt
+++ b/kontrakt/src/main/kotlin/Maksimum.kt
@@ -33,9 +33,10 @@ public data class Vedtak(
     val beregningsgrunnlag: Int,
     val barnMedStonad: Int,
     val barnetillegg: Int,
-    val barnetilleggSats: Int = 0,
+    val barnetilleggSats: Int,
     val kildesystem: Kilde,
     val samordningsId: String? = null,
+    @Deprecated("Alltid null, bør fjernes fra kontrakt.")
     val opphorsAarsak: String? = null,
     val vedtaksTypeKode: String?,
     val vedtaksTypeNavn: String?,
@@ -51,7 +52,7 @@ public data class VedtakUtenUtbetaling(
     val vedtakId: String,
     val status: String,
     val saksnummer: String,
-    val vedtaksdato: LocalDate, //reg_dato
+    val vedtaksdato: LocalDate,
     val vedtaksTypeKode: String?,
     val vedtaksTypeNavn: String?,
     val periode: Periode,
@@ -69,8 +70,8 @@ public data class VedtakUtenUtbetaling(
  */
 public data class UtbetalingMedMer(
     @property:Description("Reduksjon i utbetaling. Denne fås kun fra Arena,")
-    val reduksjon: Reduksjon? = null,
-    val utbetalingsgrad: Int? = null,
+    val reduksjon: Reduksjon?,
+    val utbetalingsgrad: Int?,
     val periode: Periode,
     val belop: Int,
     val dagsats: Int,

--- a/kontrakt/src/main/kotlin/Maksimum.kt
+++ b/kontrakt/src/main/kotlin/Maksimum.kt
@@ -31,8 +31,28 @@ public data class Vedtak(
     val periode: Periode,
     val rettighetsType: String,
     val beregningsgrunnlag: Int,
+
+    /** Antall barn som gir rett til barnetillegg. */
     val barnMedStonad: Int,
+
+    /** Størrelsen på total, ugradert barnetillegg.
+     *
+     * Verdien er total i den forstand at den tar hensyn til antall barn.
+     *
+     * Den er ugradert i den forstand at hvis medlemmet har 2 barn, får 75 % AAP
+     * på grunn av samordning, og barnetilleggssatsen er spesifisert i AAP-forskriften § 8 til 38 kroner,
+     * så vil [barnetillegg] være 2 * 38 = 76 kroner. Altså vi har ikke redusert barnetillegget med 25% her.
+     *
+     * Spesifikasjon: [barnetillegg] = [barnetilleggSats] * [barnMedStonad].
+     */
     val barnetillegg: Int,
+
+    /** Størrelsen på ugradert barnetilleggsats.
+     *
+     * Verdien er ugradert, i den forstand at:
+     * Hvis barnetilleggsatsen er spesifisert i AAP-forskriften § 8 til 38 kroner, og medlemmet får 50% AAP,
+     * så vil [barnetilleggSats] være 38.
+     **/
     val barnetilleggSats: Int,
     val kildesystem: Kilde,
     val samordningsId: String? = null,
@@ -58,7 +78,20 @@ public data class VedtakUtenUtbetaling(
     val periode: Periode,
     val rettighetsType: String,
     val beregningsgrunnlag: Int,
+
+    /** Antall barn som gir rett til barnetillegg. */
     val barnMedStonad: Int,
+
+    /** Størrelsen på total, ugradert barnetillegg.
+     *
+     * Verdien er total i den forstand at den tar hensyn til antall barn.
+     *
+     * Den er ugradert i den forstand at hvis medlemmet har 2 barn, får 75 % AAP
+     * på grunn av samordning, og barnetilleggssatsen er spesifisert i AAP-forskriften § 8 til 38 kroner,
+     * så vil [barnetillegg] være 2 * 38 = 76 kroner. Altså vi har ikke redusert barnetillegget med 25% her.
+     *
+     * Spesifikasjon: [barnetillegg] = [barnetilleggsats] * [antallBarn].
+     */
     val barnetillegg: Int,
     val kildesystem: Kilde,
     val samordningsId: String? = null,
@@ -75,11 +108,21 @@ public data class UtbetalingMedMer(
     val periode: Periode,
     val belop: Int,
     val dagsats: Int,
-    @Deprecated("Bruk barnetillegg")
-    val barnetilegg: Int,
     @property:Description("Barnetillegg, _etter_ gradering.")
+
+    /** Størrelsen på total, gradert barnetillegg.
+     *
+     * Verdien er total i den forstand at den tar hensyn til antall barn.
+     *
+     * Den er gradert i den forstand at hvis medlemmet har 2 barn, får 75 % AAP
+     * på grunn av samordning, og barnetilleggssatsen er spesifisert i AAP-forskriften § 8 til 38 kroner,
+     * så vil [barnetillegg] gi 2 * 38 * 0.75 = 57 kroner.
+     */
     val barnetillegg: Int,
-)
+) {
+    @Deprecated("Bruk barnetillegg")
+    val barnetilegg: Int = barnetillegg
+}
 
 public data class Reduksjon(
     val timerArbeidet: Double,


### PR DESCRIPTION
Fikser feil, hvor `barnetilleggSats` i VedtakService var satt til total gradert barnetillegg, og ikke ugradert barnetilleggsats.