### PR TITLE
Hent vedtaksTypeKode fra arenavedtak i hentMaksimum og hentMediumFraKelvin

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/Behandling.kt
@@ -185,5 +185,7 @@ data class Arenavedtak(
         S_OPPHOR(DsopVedtaksTypeDTO.S, DsopVedtaksvariantDTO.S_OPPHOR),
         S_STANS(DsopVedtaksTypeDTO.S, DsopVedtaksvariantDTO.S_STANS),
         ;
+
+        val typeKode: String get() = type.name
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
@@ -48,12 +48,22 @@ class VedtakService(
                     )
                 }
             ).komprimer()
+            val arenavedtakPerPeriode =
+                behandling.arenakompatibleVedtakTidslinje.splittOppIPerioder(perioderTidslinje.perioder().toList())
+            val perioderMedArena = perioderTidslinje.kombiner(
+                arenavedtakPerPeriode,
+                JoinStyle.LEFT_JOIN { periode, left, right ->
+                    Segment(periode, left.verdi.copy(arenavedtak = right?.verdi?.segmenter()?.firstOrNull()?.verdi))
+                }
+            )
             val tilkjentPerioder =
-                behandling.tilkjent.splittOppIPerioder(perioderTidslinje.perioder().toList())
+                behandling.tilkjent.splittOppIPerioder(perioderMedArena.perioder().toList())
 
-            perioderTidslinje.kombiner(
+            perioderMedArena.kombiner(
                 tilkjentPerioder,
                 JoinStyle.LEFT_JOIN { periode, left, right ->
+                    val vedtaksTypeKode = left.verdi.arenavedtak?.vedtaksvariant?.typeKode
+                        ?: if (behandling.nyttVedtak) "O" else "E"
                     Segment(
                         periode,
                         Vedtak(
@@ -72,7 +82,7 @@ class VedtakService(
                                 ?.first()?.verdi?.barnetilleggsats?.toInt()
                                 ?: 0),
                             barnetilleggSats = left.verdi.barnetilleggSats?.toInt() ?: 0,
-                            vedtaksTypeKode = null,
+                            vedtaksTypeKode = vedtaksTypeKode,
                             vedtaksTypeNavn = null,
                             utbetaling = right?.verdi?.filter {
                                 it.periode.tom.isBefore(LocalDate.now(clock)) || it.periode.tom.isEqual(
@@ -142,13 +152,24 @@ class VedtakService(
                     )
                 }
             ).komprimer()
+                .let { perioderTidslinje ->
+                    val arenavedtakPerPeriode =
+                        behandling.arenakompatibleVedtakTidslinje.splittOppIPerioder(perioderTidslinje.perioder().toList())
+                    perioderTidslinje.kombiner(
+                        arenavedtakPerPeriode,
+                        JoinStyle.LEFT_JOIN { periode, left, right ->
+                            Segment(periode, left.verdi.copy(arenavedtak = right?.verdi?.segmenter()?.firstOrNull()?.verdi))
+                        }
+                    )
+                }
                 .segmenter()
                 .map {
                     it.verdi.tilVedtakUtenUtbetaling(
                         no.nav.aap.api.intern.Periode(
                             it.periode.fom,
                             it.periode.tom
-                        )
+                        ),
+                        behandling.nyttVedtak,
                     )
                 }
                 .filter { (it.status == Status.LØPENDE.toString() || it.status == Status.AVSLUTTET.toString()) }
@@ -212,8 +233,11 @@ data class VedtakUtenUtbetalingUtenPeriode(
      * så vil [barnetilleggSats] være 38.
      **/
     val barnetilleggSats: BigDecimal? = null,
+    val arenavedtak: Arenavedtak? = null,
 ) {
-    fun tilVedtakUtenUtbetaling(periode: no.nav.aap.api.intern.Periode): VedtakUtenUtbetaling {
+    fun tilVedtakUtenUtbetaling(periode: no.nav.aap.api.intern.Periode, nyttVedtak: Boolean): VedtakUtenUtbetaling {
+        val vedtaksTypeKode = arenavedtak?.vedtaksvariant?.typeKode
+            ?: if (nyttVedtak) "O" else "E"
         return VedtakUtenUtbetaling(
             vedtakId = this.vedtakId,
             dagsats = this.dagsats,
@@ -221,7 +245,7 @@ data class VedtakUtenUtbetalingUtenPeriode(
             status = this.status,
             saksnummer = this.saksnummer,
             vedtaksdato = this.vedtaksdato,
-            vedtaksTypeKode = null,
+            vedtaksTypeKode = vedtaksTypeKode,
             vedtaksTypeNavn = null,
             periode = periode,
             rettighetsType = this.rettighetsType,

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
@@ -48,8 +48,9 @@ class VedtakService(
                     )
                 }
             ).komprimer()
-            val perioderMedArena = perioderTidslinje.leftJoin(behandling.arenakompatibleVedtakTidslinje){ left, right ->
-                left.copy(arenavedtak = right)
+            val perioderMedArena =
+                perioderTidslinje.leftJoin(behandling.arenakompatibleVedtakTidslinje) { left, right ->
+                    left.copy(arenavedtak = right)
                 }
 
             val tilkjentPerioder =
@@ -110,8 +111,6 @@ class VedtakService(
                 }
             ).komprimer().segmenter().map { it.verdi }
                 .filter { it.status == Status.LØPENDE.toString() || it.status == Status.AVSLUTTET.toString() }
-
-
         }
 
         return Maksimum(vedtak)
@@ -149,16 +148,11 @@ class VedtakService(
                 }
             ).komprimer()
                 .let { perioderTidslinje ->
-                    val arenavedtakPerPeriode =
-                        behandling.arenakompatibleVedtakTidslinje.splittOppIPerioder(perioderTidslinje.perioder().toList())
-                    perioderTidslinje.kombiner(
-                        arenavedtakPerPeriode,
-                        JoinStyle.LEFT_JOIN { periode, left, right ->
-                            Segment(periode, left.verdi.copy(arenavedtak = right?.verdi?.segmenter()?.firstOrNull()?.verdi))
-                        }
-                    )
+                    perioderTidslinje.leftJoin(behandling.arenakompatibleVedtakTidslinje) { periode, left, right ->
+                        Segment(periode, left.copy(arenavedtak = right))
+                    }
+
                 }
-                .segmenter()
                 .map {
                     it.verdi.tilVedtakUtenUtbetaling(
                         no.nav.aap.api.intern.Periode(
@@ -168,7 +162,7 @@ class VedtakService(
                         behandling.nyttVedtak,
                     )
                 }
-                .filter { (it.status == Status.LØPENDE.toString() || it.status == Status.AVSLUTTET.toString()) }
+                .filter { (it.verdi.status == Status.LØPENDE.toString() || it.verdi.status == Status.AVSLUTTET.toString()) }.verdier()
         }
 
         return Medium(vedtak)
@@ -215,13 +209,15 @@ data class VedtakUtenUtbetalingUtenPeriode(
     val samordningsId: String? = null,
     val opphorsAarsak: String? = null,
 
-    @param:Description("""
+    @param:Description(
+        """
      Størrelsen på ugradert barnetilleggsats.
     
     Verdien er ugradert, i den forstand at:
     Hvis barnetilleggsatsen er spesifisert i AAP-forskriften § 8 til 38 kroner, og medlemmet får 50% AAP,
     så vil [barnetilleggSats] være 38.
-    """)
+    """
+    )
     /** Størrelsen på ugradert barnetilleggsats.
      *
      * Verdien er ugradert, i den forstand at:

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/VedtakService.kt
@@ -48,14 +48,10 @@ class VedtakService(
                     )
                 }
             ).komprimer()
-            val arenavedtakPerPeriode =
-                behandling.arenakompatibleVedtakTidslinje.splittOppIPerioder(perioderTidslinje.perioder().toList())
-            val perioderMedArena = perioderTidslinje.kombiner(
-                arenavedtakPerPeriode,
-                JoinStyle.LEFT_JOIN { periode, left, right ->
-                    Segment(periode, left.verdi.copy(arenavedtak = right?.verdi?.segmenter()?.firstOrNull()?.verdi))
+            val perioderMedArena = perioderTidslinje.leftJoin(behandling.arenakompatibleVedtakTidslinje){ left, right ->
+                left.copy(arenavedtak = right)
                 }
-            )
+
             val tilkjentPerioder =
                 behandling.tilkjent.splittOppIPerioder(perioderMedArena.perioder().toList())
 

--- a/app/src/test/resources/forstegangsvedtak_fra_maksimum.json
+++ b/app/src/test/resources/forstegangsvedtak_fra_maksimum.json
@@ -19,7 +19,7 @@
       "kildesystem": "KELVIN",
       "samordningsId": null,
       "opphorsAarsak": null,
-      "vedtaksTypeKode": null,
+      "vedtaksTypeKode": "E",
       "vedtaksTypeNavn": null,
       "utbetaling": [
         {
@@ -55,7 +55,7 @@
       "kildesystem": "KELVIN",
       "samordningsId": null,
       "opphorsAarsak": null,
-      "vedtaksTypeKode": null,
+      "vedtaksTypeKode": "E",
       "vedtaksTypeNavn": null,
       "utbetaling": []
     }

--- a/app/src/test/resources/forstegangsvedtak_fra_medium.json
+++ b/app/src/test/resources/forstegangsvedtak_fra_medium.json
@@ -19,7 +19,7 @@
       "kildesystem": "KELVIN",
       "samordningsId": null,
       "opphorsAarsak": null,
-      "vedtaksTypeKode": null,
+      "vedtaksTypeKode": "E",
       "vedtaksTypeNavn": null
     },
     {
@@ -41,7 +41,7 @@
       "kildesystem": "KELVIN",
       "samordningsId": null,
       "opphorsAarsak": null,
-      "vedtaksTypeKode": null,
+      "vedtaksTypeKode": "E",
       "vedtaksTypeNavn": null
     }
   ]


### PR DESCRIPTION
Legger til støtte for å hente vedtaksTypeKode (O, E, G, S) fra arenavedtak i VedtakService, på samme måte som utledDsopVedtak gjør i DsopService.

- Legger til typeKode-property på Arenavedtak.Vedtaksvariant
- Legger til arenavedtak-felt på VedtakUtenUtbetalingUtenPeriode
- Slår sammen arenakompatibleVedtakTidslinje i begge metodene via LEFT_JOIN
- Fallback: 'O' for nytt vedtak, 'E' for endring (når ingen arenavedtak)
- Oppdaterer snapshot-tester