### PR TITLE
feat: gi dp-andre-ytelser lesetilgang til aap.api-intern-hendelse-v1

### DIFF
--- a/.nais/topic-dev.yaml
+++ b/.nais/topic-dev.yaml
@@ -14,3 +14,6 @@ spec:
     - application: api-intern
       team: aap
       access: readwrite
+    - application: dp-andre-ytelser
+      team: teamdagpenger
+      access: read

--- a/.nais/topic-prod.yaml
+++ b/.nais/topic-prod.yaml
@@ -14,3 +14,6 @@ spec:
     - application: api-intern
       team: aap
       access: readwrite
+    - application: dp-andre-ytelser
+      team: teamdagpenger
+      access: read


### PR DESCRIPTION
## Hva
Gir `dp-andre-ytelser` (teamdagpenger) `read`-tilgang til topicen `aap.api-intern-hendelse-v1` i dev og prod.

## Hvorfor
Dagpenger-teamet bygger en tjeneste som lytter på vedtakshendelser fra andre ytelser (foreldrepenger, sykmelding, AAP m.fl.) for å trigge revurdering av dagpengesaker.

## Endringer
- `.nais/topic-dev.yaml`: Lagt til ACL-entry for `dp-andre-ytelser` med `read`
- `.nais/topic-prod.yaml`: Lagt til ACL-entry for `dp-andre-ytelser` med `read`

Takk for hjelpen! 🙏