### PR TITLE
Fjern API som nå er ubrukt

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/App.kt
@@ -44,12 +44,10 @@ import no.nav.aap.komponenter.dbmigrering.Migrering
 import no.nav.aap.komponenter.server.auth.IdentityProvider
 import no.nav.aap.komponenter.server.commonKtorModule
 import no.nav.aap.motor.Motor
-import no.nav.aap.motor.Motor.Companion.invoke
 import no.nav.aap.motor.api.motorApi
 import no.nav.aap.motor.mdc.NoExtraLogInfoProvider
 import no.nav.aap.motor.retry.RetryService
 import org.slf4j.LoggerFactory
-import kotlin.time.Duration.Companion.seconds
 
 private val logger = LoggerFactory.getLogger("App")
 
@@ -173,14 +171,7 @@ fun Application.module(dataSource: DataSource): Motor {
 
 private fun opprettArenaService(config: AppConfig): ArenaService {
     val arenaRestGateway = ArenaoppslagGateway(config.arenaoppslag)
-    val arenaHistorikkGateway = ArenaoppslagGateway(
-        arenaoppslagConfig = config.arenaoppslag,
-        // Vi øker timeouts fordi disse db-queries er tunge
-        timeoutMillis = 2.minutes.inWholeMilliseconds,
-        slowRequestMillis = 1.minutes.inWholeMilliseconds,
-        cacheName = "arenaoppslag_historikk_maksimum_cache",
-    )
 
-    return ArenaService(arenaRestGateway, arenaHistorikkGateway)
+    return ArenaService(arenaRestGateway)
 }
 

--- a/app/src/main/kotlin/no/nav/aap/api/Routes.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/Routes.kt
@@ -26,7 +26,6 @@ import no.nav.aap.api.postgres.MeldekortPerioderRepository
 import no.nav.aap.api.postgres.SakStatusRepository
 import no.nav.aap.api.util.perioderMedAAp
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.komponenter.config.requiredConfigForKey
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
@@ -341,41 +340,6 @@ fun NormalOpenAPIRoute.api(
         }
     }
     tag(Tag.ArenaHistorikk) {
-        route("/arena/person/aap/eksisterer") {
-            post<CallIdHeader, PersonEksistererIAAPArena, SakerRequest>(
-                info(description = "Sjekker om en person eksisterer i Arena (AAP).")
-            ) { callIdHeader, requestBody ->
-                logger.info("Sjekker om person eksisterer i aap-arena")
-                val callId = receiveCall(callIdHeader, pipeline)
-
-                pipeline.call.response.headers.append(
-                    HttpHeaders.ContentType,
-                    ContentType.Application.Json.withCharset(Charsets.UTF_8).toString()
-                )
-                val eksistererIAAPArena =
-                    arenaService.eksistererIAapArena(callId, requestBody.personidentifikatorer)
-                respond(eksistererIAAPArena)
-            }
-        }
-        route("/arena/person/aap/signifikant-historikk") {
-            post<CallIdHeader, SignifikanteSakerResponse, SignifikanteSakerRequest>(
-                info(description = "Sjekker om en person kan behandles i Kelvin mtp. AAP-Arena-historikken deres.")
-            ) { callIdHeader, requestBody ->
-                logger.info("Sjekker om personen kan behandles i Kelvin")
-                val callId = receiveCall(callIdHeader, pipeline)
-                pipeline.call.response.headers.append(
-                    HttpHeaders.ContentType,
-                    ContentType.Application.Json.withCharset(Charsets.UTF_8).toString()
-                )
-
-                val harSignifikantAAPArenaHistorikk = arenaService.harSignifikantAAPArenaHistorikk(
-                    callId,
-                    requestBody.personidentifikatorer,
-                    requestBody.virkningstidspunkt
-                )
-                respond(harSignifikantAAPArenaHistorikk)
-            }
-        }
         route("/arena/person/saker") {
             post<CallIdHeader, ArenaSakerResponse, ArenaSakerRequest>(
                 info(description = "Henter saker for en person fra Arena via ny v1-kontrakt.")

--- a/app/src/main/kotlin/no/nav/aap/api/arena/ArenaService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/arena/ArenaService.kt
@@ -5,9 +5,7 @@ import no.nav.aap.api.intern.ArenaSakerResponse
 import no.nav.aap.api.intern.Periode
 import no.nav.aap.api.intern.PeriodeInkludert11_17
 import no.nav.aap.api.intern.PerioderInkludert11_17Response
-import no.nav.aap.api.intern.PersonEksistererIAAPArena
 import no.nav.aap.api.intern.SakStatus
-import no.nav.aap.api.intern.SignifikanteSakerResponse
 import no.nav.aap.api.intern.Vedtak
 import no.nav.aap.api.intern.VedtakUtenUtbetaling
 import no.nav.aap.api.util.fraKontrakt
@@ -15,37 +13,12 @@ import no.nav.aap.api.util.fraKontraktUtenUtbetaling
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.Status
-import java.time.LocalDate
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
 
 class ArenaService(
-    private val arena: IArenaoppslagGateway,
-    private val arenaHistorikk: IArenaoppslagGateway
+    private val arena: IArenaoppslagGateway
 ) {
-
-
-    suspend fun eksistererIAapArena(callId: String, personIdenter: List<String>): PersonEksistererIAAPArena {
-        val aapHistorikkForPerson = arenaHistorikk.hentPersonEksistererIAapContext(callId, SakerRequest(personIdenter))
-        return PersonEksistererIAAPArena(aapHistorikkForPerson.eksisterer)
-    }
-
-    suspend fun harSignifikantAAPArenaHistorikk(
-        callId: String,
-        personIdenter: List<String>,
-        virkningstidspunkt: LocalDate
-    ): SignifikanteSakerResponse {
-        val harSignifikantAAPArenaHistorikk =
-            arenaHistorikk.hentPersonHarSignifikantHistorikk(
-                callId,
-                SignifikanteSakerRequest(personIdenter, virkningstidspunkt)
-            )
-        return SignifikanteSakerResponse(
-            harSignifikantAAPArenaHistorikk.harSignifikantHistorikk,
-            harSignifikantAAPArenaHistorikk.signifikanteSaker
-        )
-    }
 
     suspend fun aktivitetfase(callId: String, vedtakRequest: InternVedtakRequest): PerioderInkludert11_17Response {
         val arenaSvar = arena.hentPerioderInkludert11_17(callId, vedtakRequest)

--- a/app/src/main/kotlin/no/nav/aap/api/arena/ArenaoppslagGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/arena/ArenaoppslagGateway.kt
@@ -28,11 +28,8 @@ import no.nav.aap.api.util.findRootCause
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.PerioderMed11_17Response
-import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakStatus
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Maksimum
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -71,12 +68,6 @@ class ArenaoppslagGateway(
         .expireAfterWrite(Duration.ofMinutes(15))
         .recordStats()
         .build<String, Maksimum>()
-
-    private val personEksistererCache = Caffeine.newBuilder()
-        .maximumSize(10_000)
-        .expireAfterWrite(Duration.ofMinutes(15))
-        .recordStats()
-        .build<String, PersonEksistererIAAPArena>()
 
     init {
         CaffeineCacheMetrics.monitor(prometheus, maksimumCache, cacheName)
@@ -123,25 +114,6 @@ class ArenaoppslagGateway(
                 .getOrThrow()
                 .also { maksimumCache.put(key, it) }
     }
-
-    override suspend fun hentPersonEksistererIAapContext(
-        callId: String, req: SakerRequest,
-    ): PersonEksistererIAAPArena {
-        val key = req.toString()
-        return personEksistererCache.getIfPresent(key)
-            ?: gjørArenaOppslag<PersonEksistererIAAPArena, SakerRequest>(
-                "/api/v1/person/eksisterer", callId, req
-            ).getOrThrow()
-                .also { personEksistererCache.put(key, it) }
-    }
-
-    override suspend fun hentPersonHarSignifikantHistorikk(
-        callId: String,
-        req: SignifikanteSakerRequest,
-    ): SignifikanteSakerResponse =
-        gjørArenaOppslag<SignifikanteSakerResponse, SignifikanteSakerRequest>(
-            "/api/v1/person/signifikant-historikk", callId, req
-        ).getOrThrow()
 
     private suspend inline fun <reified T, reified V> gjørArenaOppslag(
         endepunkt: String, callId: String, req: V, tillattMed404: Boolean = false

--- a/app/src/main/kotlin/no/nav/aap/api/arena/IArenaoppslagGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/arena/IArenaoppslagGateway.kt
@@ -3,10 +3,7 @@ package no.nav.aap.api.arena
 import no.nav.aap.api.intern.PerioderResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.PerioderMed11_17Response
-import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Maksimum
@@ -17,16 +14,6 @@ interface IArenaoppslagGateway {
         callId: String,
         req: InternVedtakRequest
     ): PerioderMed11_17Response
-
-    suspend fun hentPersonEksistererIAapContext(
-        callId: String,
-        req: SakerRequest
-    ): PersonEksistererIAAPArena
-
-    suspend fun hentPersonHarSignifikantHistorikk(
-        callId: String,
-        req: SignifikanteSakerRequest
-    ): SignifikanteSakerResponse
 
     suspend fun hentSakerByFnr(
         callId: String,

--- a/app/src/test/kotlin/no/nav/aap/api/KontraktTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/KontraktTest.kt
@@ -23,7 +23,6 @@ class KontraktTest : PostgresTestBase() {
         "no.nav.aap.api.SakerRequest",
         "no.nav.aap.api.SakerRequestMeldekortbackend",
         "no.nav.aap.api.kelvin.MeldekortPerioderDTO",
-        "no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest",
         "no.nav.aap.komponenter.type.Periode",
     )
 

--- a/app/src/test/kotlin/no/nav/aap/api/TestApp.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/TestApp.kt
@@ -31,7 +31,7 @@ fun main() {
             prometheus = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
             config = config,
             datasource = dataSource,
-            arenaService = ArenaService(FakeArenaGateway(), FakeArenaGateway()),
+            arenaService = ArenaService(FakeArenaGateway()),
             pdlGateway = PdlGatewayEmpty(),
             modiaProducer = fakes.kafka,
             aapHendelseProducer = fakes.aapHendelse,

--- a/app/src/test/kotlin/no/nav/aap/api/arena/ArenaOppslagTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/arena/ArenaOppslagTest.kt
@@ -11,19 +11,14 @@ import io.ktor.serialization.jackson.*
 import io.ktor.server.testing.*
 import no.nav.aap.api.TestConfig
 import no.nav.aap.api.api
-import no.nav.aap.api.intern.PersonEksistererIAAPArena
-import no.nav.aap.api.intern.SignifikanteSakerResponse
 import no.nav.aap.api.util.AzureTokenGen
 import no.nav.aap.api.util.Fakes
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
-import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 
 
 class ArenaOppslagTest {
@@ -55,38 +50,6 @@ class ArenaOppslagTest {
                 )
             }
             testBlock(token)
-        }
-    }
-
-    @Test
-    fun `kan kalle på aap-eksisterer`() {
-        testWithKtorApp { token ->
-            val res = jsonHttpClient.post("/arena/person/aap/eksisterer") {
-                bearerAuth(token.generate(isApp = true))
-                contentType(ContentType.Application.Json)
-                setBody(SakerRequest(personidentifikatorer = listOf("12345678910")))
-            }
-            assertThat(res).isNotNull()
-            assertThat(res.status).isEqualTo(HttpStatusCode.OK)
-            val parsedBody = res.body<PersonEksistererIAAPArena>()
-            assertThat(parsedBody).isNotNull
-            assertThat(parsedBody.eksisterer).isFalse // forventet respons fra MockedArenaClient
-        }
-    }
-
-    @Test
-    fun `kan kalle på kan behandles i Kelvin`() {
-        testWithKtorApp { token ->
-            val res = jsonHttpClient.post("/arena/person/aap/signifikant-historikk") {
-                bearerAuth(token.generate(isApp = true))
-                contentType(ContentType.Application.Json)
-                setBody(SignifikanteSakerRequest(listOf("12345678910"), LocalDate.now()))
-            }
-            assertThat(res).isNotNull()
-            assertThat(res.status).isEqualTo(HttpStatusCode.OK)
-            val parsedBody = res.body<SignifikanteSakerResponse>()
-            assertThat(parsedBody).isNotNull
-            assertThat(parsedBody.harSignifikantHistorikk).isFalse // forventet respons fra MockedArenaClient
         }
     }
 

--- a/app/src/test/kotlin/no/nav/aap/api/util/ArenaEmpty.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/util/ArenaEmpty.kt
@@ -6,11 +6,8 @@ import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakOppsummeringKontrakt
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.PerioderMed11_17Response
-import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakStatus
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Maksimum
 import java.time.LocalDate
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
@@ -24,19 +21,6 @@ class FakeArenaGateway : IArenaoppslagGateway {
         callId: String, req: InternVedtakRequest
     ): PerioderMed11_17Response {
         return PerioderMed11_17Response(emptyList())
-    }
-
-    override suspend fun hentPersonEksistererIAapContext(
-        callId: String, req: SakerRequest
-    ): PersonEksistererIAAPArena {
-        return PersonEksistererIAAPArena(false)
-    }
-
-    override suspend fun hentPersonHarSignifikantHistorikk(
-        callId: String,
-        req: SignifikanteSakerRequest
-    ): SignifikanteSakerResponse {
-        return SignifikanteSakerResponse(false, emptyList())
     }
 
     override suspend fun hentSakerByFnr(
@@ -71,7 +55,6 @@ class FakeArenaGateway : IArenaoppslagGateway {
             else -> error("Ukjent personidentifikator i FakeArenaGateway: ${req.personidentifikator}")
         }
     }
-
 
     override suspend fun hentMaksimum(
         callId: String, req: InternVedtakRequest

--- a/app/src/test/kotlin/no/nav/aap/api/util/Fakes.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/util/Fakes.kt
@@ -32,7 +32,7 @@ class Fakes : AutoCloseable {
     val oppgave = embeddedServer(Netty, port = 0, module = Application::oppgaveFake).start()
     val kafka = KafkaFake()
     val aapHendelse = AapHendelseKafkaFake()
-    val arenaService = ArenaService(FakeArenaGateway(), FakeArenaGateway())
+    val arenaService = ArenaService(FakeArenaGateway())
 
     override fun close() {
         texas.stop(0L, 0L)

--- a/kontrakt/src/main/kotlin/Arena.kt
+++ b/kontrakt/src/main/kotlin/Arena.kt
@@ -1,22 +1,6 @@
 package no.nav.aap.api.intern
 
-import com.papsign.ktor.openapigen.annotations.properties.description.Description
 import java.time.LocalDate
-
-public data class SignifikanteSakerResponse(
-    val harSignifikantHistorikk: Boolean,
-    val signifikanteSaker: List<String> // signifikante Arena-saker, sortert på dato, nyeste først
-)
-
-public data class PersonEksistererIAAPArena(
-    @property:Description("True om personen eksisterer i Arena.")
-    val eksisterer: Boolean
-)
-
-public data class SignifikanteSakerRequest (
-    val personidentifikatorer: List<String>,
-    val virkningstidspunkt: LocalDate, // datoen søknaden ble mottatt, feks. per post
-)
 
 public data class ArenaSakerRequest(
     val personidentifikator: String,


### PR DESCRIPTION
For arena-historikk. Denne hentes nå direkte hos aap-arenaoppslag.

OBS: krever en oppdatering av behandlingsflyt til å bruke nytt API-endepunkt (hos arenaoppslag). 
Den planlagte utvidelsen av arena-historikk-visning i Saksbehandling i Kelvin gjør at vi kan fjerne bruken totalt når den er på plass. 