### PR TITLE
Endepunkt syfo dialogmelding

### DIFF
--- a/.nais/app-dev.yml
+++ b/.nais/app-dev.yml
@@ -137,6 +137,8 @@ spec:
         - application: paw-patrol
         - application: veilarboppfolging
           namespace: poao
+        - application: padm2
+          namespace: teamsykefravr
     outbound:
       external:
         - host: arenaoppslag.dev-fss-pub.nais.io
@@ -145,6 +147,7 @@ spec:
         - application: behandlingsflyt
         - application: tilgang
         - application: oppgave
+        - application: dokumentinnhenting
         - application: logging
           namespace: nais-system
   env:
@@ -178,3 +181,5 @@ spec:
       value: d476981c-d129-4402-a74d-ea35a03cac5c
     - name: AZP_VEILARBOPPFOLGING
       value: 52106802-f42e-4587-8547-6289d1df6cac
+    - name: AZP_PADM2
+      value: 37e3a2ac-c5f3-4c65-a245-59c04a41f6d4

--- a/.nais/app-dev.yml
+++ b/.nais/app-dev.yml
@@ -167,6 +167,10 @@ spec:
       value: http://oppgave
     - name: INTEGRASJON_OPPGAVE_SCOPE
       value: api://dev-gcp.aap.oppgave/.default
+    - name: INTEGRASJON_DOKUMENTINNHENTING_URL
+      value: http://dokumentinnhenting
+    - name: INTEGRASJON_DOKUMENTINNHENTING_SCOPE
+      value: api://dev-gcp.aap.dokumentinnhenting/.default
     - name: MODIA_TOPIC
       value: obo.ytelser-v1
     - name: AAP_HENDELSE_TOPIC

--- a/.nais/app-prod.yml
+++ b/.nais/app-prod.yml
@@ -122,7 +122,7 @@ spec:
         - application: veilarboppfolging
           namespace: poao
         - application: padm2
-          namespace: teamsykefravr # Syfo
+          namespace: teamsykefravr
     outbound:
       external:
         - host: arenaoppslag.prod-fss-pub.nais.io
@@ -151,6 +151,10 @@ spec:
       value: http://oppgave
     - name: INTEGRASJON_OPPGAVE_SCOPE
       value: api://prod-gcp.aap.oppgave/.default
+    - name: INTEGRASJON_DOKUMENTINNHENTING_URL
+      value: http://dokumentinnhenting
+    - name: INTEGRASJON_DOKUMENTINNHENTING_SCOPE
+      value: api://prod-gcp.aap.dokumentinnhenting/.default
     - name: MODIA_TOPIC
       value: obo.ytelser-v1
     - name: AAP_HENDELSE_TOPIC

--- a/.nais/app-prod.yml
+++ b/.nais/app-prod.yml
@@ -121,6 +121,8 @@ spec:
         - application: paw-patrol
         - application: veilarboppfolging
           namespace: poao
+        - application: padm2
+          namespace: teamsykefravr # Syfo
     outbound:
       external:
         - host: arenaoppslag.prod-fss-pub.nais.io
@@ -129,6 +131,7 @@ spec:
         - application: behandlingsflyt
         - application: tilgang
         - application: oppgave
+        - application: dokumentinnhenting
         - application: logging
           namespace: nais-system
   env:
@@ -160,3 +163,5 @@ spec:
       value: 1626e9aa-354f-49aa-ba99-50e33f6bd908
     - name: AZP_VEILARBOPPFOLGING
       value: 997264c7-13dc-4c9e-817a-90789acb35ba
+    - name: AZP_PADM2
+      value: 5dc2db90-da0b-42a5-850c-522ea0b6160c

--- a/app/src/main/kotlin/no/nav/aap/api/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/App.kt
@@ -1,8 +1,14 @@
 package no.nav.aap.api
 
+import com.papsign.ktor.openapigen.APITag
 import com.papsign.ktor.openapigen.model.info.ContactModel
 import com.papsign.ktor.openapigen.model.info.InfoModel
+import com.papsign.ktor.openapigen.model.operation.ParameterLocation
+import com.papsign.ktor.openapigen.route.OpenAPIRoute
 import com.papsign.ktor.openapigen.route.apiRouting
+import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
+import com.papsign.ktor.openapigen.route.route
+import com.papsign.ktor.openapigen.route.tag
 import com.zaxxer.hikari.HikariDataSource
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStarted
@@ -16,6 +22,7 @@ import io.ktor.server.engine.connector
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import java.time.Clock
@@ -45,12 +52,11 @@ import no.nav.aap.komponenter.miljo.Miljø
 import no.nav.aap.komponenter.server.auth.IdentityProvider
 import no.nav.aap.komponenter.server.commonKtorModule
 import no.nav.aap.motor.Motor
-import no.nav.aap.motor.Motor.Companion.invoke
 import no.nav.aap.motor.api.motorApi
 import no.nav.aap.motor.mdc.NoExtraLogInfoProvider
 import no.nav.aap.motor.retry.RetryService
 import org.slf4j.LoggerFactory
-import kotlin.time.Duration.Companion.seconds
+import no.nav.aap.api.kelvin.DokumentinnhentingGateway
 
 private val logger = LoggerFactory.getLogger("App")
 
@@ -127,6 +133,11 @@ fun Application.api(
     routing {
         authenticate(IdentityProvider.ENTRA_ID.value) {
             apiRouting {
+                tag(Tag.Syfo) {
+                    route("/syfo/v1") {
+                        dialogmeldingApi(DokumentinnhentingGateway())
+                    }
+                }
                 api(datasource, arenaService, pdlGateway, clock)
                 dataInsertion(datasource)
                 motorApi(datasource)
@@ -209,4 +220,3 @@ private fun opprettArenaService(config: AppConfig): ArenaService {
 
     return ArenaService(arenaRestGateway, arenaHistorikkGateway)
 }
-

--- a/app/src/main/kotlin/no/nav/aap/api/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/App.kt
@@ -1,12 +1,8 @@
 package no.nav.aap.api
 
-import com.papsign.ktor.openapigen.APITag
 import com.papsign.ktor.openapigen.model.info.ContactModel
 import com.papsign.ktor.openapigen.model.info.InfoModel
-import com.papsign.ktor.openapigen.model.operation.ParameterLocation
-import com.papsign.ktor.openapigen.route.OpenAPIRoute
 import com.papsign.ktor.openapigen.route.apiRouting
-import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
 import com.papsign.ktor.openapigen.route.route
 import com.papsign.ktor.openapigen.route.tag
 import com.zaxxer.hikari.HikariDataSource
@@ -22,7 +18,6 @@ import io.ktor.server.engine.connector
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.statuspages.StatusPages
-import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import java.time.Clock

--- a/app/src/main/kotlin/no/nav/aap/api/DialogmeldingApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/DialogmeldingApi.kt
@@ -1,0 +1,29 @@
+package no.nav.aap.api
+
+import behandlingsflyt.DialogmeldingEksistererDto
+import com.papsign.ktor.openapigen.annotations.parameters.PathParam
+import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
+import com.papsign.ktor.openapigen.route.response.respond
+import com.papsign.ktor.openapigen.route.route
+import java.util.UUID
+import no.nav.aap.api.kelvin.DokumentinnhentingGateway
+import no.nav.aap.komponenter.config.requiredConfigForKey
+import no.nav.aap.tilgang.AuthorizationMachineToMachineConfig
+import no.nav.aap.tilgang.authorizedGet
+
+data class DialogmeldingIdParameter(@param:PathParam("dialogmeldingId") val dialogmeldingId: UUID)
+
+fun NormalOpenAPIRoute.dialogmeldingApi(dokumentinnhentingGateway: DokumentinnhentingGateway) {
+    route("/dialogmelding") {
+        route("/{dialogmeldingId}/eksisterer").authorizedGet<DialogmeldingIdParameter, DialogmeldingEksistererDto>(
+            AuthorizationMachineToMachineConfig(
+                listOf(UUID.fromString(requiredConfigForKey("AZP_PADM2")))
+            )
+        ) { params ->
+            val dto = dokumentinnhentingGateway.dialogmeldingEksisterer(params.dialogmeldingId)
+
+            respond(dto)
+        }
+
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/api/Routes.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/Routes.kt
@@ -63,7 +63,9 @@ enum class Tag(override val description: String) : APITag {
     Maksimum("For å hente maksimumsløsning"),
     DSOP("For DSOP-relaterte endepunkter"),
     OBO("Endepunkter ment for Team OBO."),
-    ArenaHistorikk("For å hente informasjon om AAP historikk fra Arena"), ;
+    ArenaHistorikk("For å hente informasjon om AAP historikk fra Arena"),
+    Syfo("Endepunkter brukt av Syfo"),
+    ;
 }
 
 data class SakerRequest(

--- a/app/src/main/kotlin/no/nav/aap/api/kelvin/DokumentinnhentingGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/kelvin/DokumentinnhentingGateway.kt
@@ -1,0 +1,37 @@
+package no.nav.aap.api.kelvin
+
+import behandlingsflyt.DialogmeldingEksistererDto
+import java.net.URI
+import java.util.UUID
+import no.nav.aap.komponenter.config.requiredConfigForKey
+import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
+import no.nav.aap.komponenter.httpklient.httpclient.Header
+import no.nav.aap.komponenter.httpklient.httpclient.RestClient
+import no.nav.aap.komponenter.httpklient.httpclient.get
+import no.nav.aap.komponenter.httpklient.httpclient.request.GetRequest
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureM2MTokenProvider
+
+class DokumentinnhentingGateway {
+    private val baseUrl = URI.create(requiredConfigForKey("INTEGRASJON_DOKUMENTINNHENTING_URL"))
+    private val config = ClientConfig(scope = requiredConfigForKey("INTEGRASJON_DOKUMENTINNHENTING_SCOPE"))
+
+    private val client = RestClient.withDefaultResponseHandler(
+        config = config,
+        tokenProvider = AzureM2MTokenProvider,
+    )
+
+    fun dialogmeldingEksisterer(
+        dialogmeldingId: UUID,
+    ): DialogmeldingEksistererDto {
+        return requireNotNull(
+            client.get<DialogmeldingEksistererDto>(
+                uri = baseUrl.resolve("/dialogmelding/$dialogmeldingId/eksisterer"),
+                request = GetRequest(
+                    additionalHeaders = listOf(
+                        Header("Accept", "application/json")
+                    )
+                ),
+            )
+        )
+    }
+}

--- a/app/src/test/kotlin/no/nav/aap/api/KontraktTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/KontraktTest.kt
@@ -3,19 +3,23 @@ package no.nav.aap.api
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import io.ktor.client.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
-import io.ktor.serialization.jackson.*
-import io.ktor.server.testing.*
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
 import no.nav.aap.api.util.Fakes
 import no.nav.aap.api.util.PdlGatewayEmpty
 import no.nav.aap.api.util.PostgresTestBase
+import no.nav.aap.api.util.WithFakes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
+@WithFakes
 class KontraktTest : PostgresTestBase() {
     /* Det er ikke til å unngå at listen ikke er tom, siden det er behandlingsflyt sin kontrakt som styrer
      * insert-endepunktene. Utenom det, så hadde denne listen ideelt sett vært tom. */
@@ -29,7 +33,6 @@ class KontraktTest : PostgresTestBase() {
 
     @Test
     fun `schemas kommer kun fra kontrakter`() {
-        Fakes().use { fakes ->
             val config = TestConfig.default()
 
             testApplication {
@@ -37,9 +40,9 @@ class KontraktTest : PostgresTestBase() {
                     api(
                         config = config,
                         datasource = dataSource,
-                        arenaService = fakes.arenaService,
-                        modiaProducer = fakes.kafka,
-                        aapHendelseProducer = fakes.aapHendelse,
+                        arenaService = Fakes.getArenaService(),
+                        modiaProducer = Fakes.getKafka(),
+                        aapHendelseProducer = Fakes.getAapHendelse(),
                         pdlGateway = PdlGatewayEmpty(),
                     )
                 }
@@ -60,7 +63,6 @@ class KontraktTest : PostgresTestBase() {
                         { it.startsWith("no.nav.aap.api.intern.") },
                         { it.startsWith("no.nav.aap.behandlingsflyt.kontrakt.") },
                     )
-                }
             }
         }
     }

--- a/app/src/test/kotlin/no/nav/aap/api/TestApp.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/TestApp.kt
@@ -11,39 +11,36 @@ import no.nav.aap.api.kafka.KafkaConfig
 import no.nav.aap.api.util.FakeArenaGateway
 import no.nav.aap.api.util.Fakes
 import no.nav.aap.api.util.PdlGatewayEmpty
-import no.nav.aap.api.util.port
 import no.nav.aap.komponenter.dbtest.TestDataSource
 
 fun main() {
-    val fakes = Fakes()
+    Fakes.start()
     val dataSource = TestDataSource()
-
-    val config = byggAppConfig(fakes)
 
     println("===========================================")
     println("  TestApp kjører på http://localhost:8084")
-    println("  Fake Texas kjører på http://localhost:${fakes.texas.port()}")
-    println("  Hent token: POST http://localhost:${fakes.texas.port()}/token")
+    println("  Fake Texas kjører på http://localhost:${Fakes.getTexasPort()}")
+    println("  Hent token: POST http://localhost:${Fakes.getTexasPort()}/token")
     println("===========================================")
 
     embeddedServer(Netty, port = 8084) {
         api(
             prometheus = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
-            config = config,
+            config = byggAppConfig(),
             datasource = dataSource,
             arenaService = ArenaService(FakeArenaGateway(), FakeArenaGateway()),
             pdlGateway = PdlGatewayEmpty(),
-            modiaProducer = fakes.kafka,
-            aapHendelseProducer = fakes.aapHendelse,
+            modiaProducer = Fakes.getKafka(),
+            aapHendelseProducer = Fakes.getAapHendelse(),
         )
-        loggStoppOgRyddOpp(fakes, dataSource)
+        loggStoppOgRyddOpp(Fakes, dataSource)
     }.start(wait = true)
 }
 
-private fun byggAppConfig(fakes: Fakes): AppConfig {
+private fun byggAppConfig(): AppConfig {
     return AppConfig(
         arenaoppslag = ArenaoppslagConfig(
-            proxyBaseUrl = "http://localhost:${fakes.arena.port()}",
+            proxyBaseUrl = "http://localhost:${Fakes.getArenaPort()}",
             scope = "test"
         ),
         dbConfig = DbConfig(

--- a/app/src/test/kotlin/no/nav/aap/api/arena/ArenaOppslagTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/arena/ArenaOppslagTest.kt
@@ -2,40 +2,44 @@ package no.nav.aap.api.arena
 
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.request.*
-import io.ktor.http.*
-import io.ktor.serialization.jackson.*
-import io.ktor.server.testing.*
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import java.time.LocalDate
 import no.nav.aap.api.TestConfig
 import no.nav.aap.api.api
 import no.nav.aap.api.intern.PersonEksistererIAAPArena
 import no.nav.aap.api.intern.SignifikanteSakerResponse
 import no.nav.aap.api.util.AzureTokenGen
 import no.nav.aap.api.util.Fakes
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
+import no.nav.aap.api.util.WithFakes
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 
-
+@WithFakes
 class ArenaOppslagTest {
     companion object {
 
-        private val fakes = Fakes()
         private val dataSource = TestDataSource()
 
         @AfterAll
         @JvmStatic
         fun afterAll() {
-            Fakes().close()
             dataSource.close()
         }
     }
@@ -49,9 +53,9 @@ class ArenaOppslagTest {
                 api(
                     config = config,
                     datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    aapHendelseProducer = fakes.aapHendelse,
+                    arenaService = Fakes.getArenaService(),
+                    modiaProducer = Fakes.getKafka(),
+                    aapHendelseProducer = Fakes.getAapHendelse(),
                 )
             }
             testBlock(token)

--- a/app/src/test/kotlin/no/nav/aap/api/dsop/DsopServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/dsop/DsopServiceTest.kt
@@ -1,10 +1,27 @@
 package no.nav.aap.api.dsop
 
-import no.nav.aap.api.intern.*
-import no.nav.aap.api.kelvin.*
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+import no.nav.aap.api.intern.DsopMeldekortDTO
+import no.nav.aap.api.intern.DsopRettighetsTypeDTO
+import no.nav.aap.api.intern.DsopStatusDTO
+import no.nav.aap.api.intern.DsopTimerArbeidetPerDagDTO
+import no.nav.aap.api.intern.DsopVedtakDTO
+import no.nav.aap.api.intern.DsopVedtaksTypeDTO
+import no.nav.aap.api.intern.DsopVedtaksvariantDTO
+import no.nav.aap.api.intern.PeriodeNullableTomDTO
+import no.nav.aap.api.intern.Utfall
+import no.nav.aap.api.kelvin.Arenavedtak
+import no.nav.aap.api.kelvin.Behandling
+import no.nav.aap.api.kelvin.KelvinBehandlingStatus
+import no.nav.aap.api.kelvin.RettighetsTypePeriode
+import no.nav.aap.api.kelvin.Sak
 import no.nav.aap.api.postgres.BehandlingsRepository
 import no.nav.aap.api.somDTO
 import no.nav.aap.api.util.PdlGatewayEmpty
+import no.nav.aap.api.util.WithFakes
 import no.nav.aap.behandlingsflyt.kontrakt.statistikk.RettighetsType
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
@@ -12,23 +29,22 @@ import no.nav.aap.komponenter.tidslinje.Tidslinje
 import no.nav.aap.komponenter.tidslinje.tidslinjeOf
 import no.nav.aap.komponenter.type.Periode
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.util.*
+import org.junit.jupiter.api.TestInstance
 
+@WithFakes
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DsopServiceTest {
     private lateinit var dataSource: TestDataSource
 
-    @BeforeEach
+    @BeforeAll
     fun setUp() {
         dataSource = TestDataSource()
     }
 
-    @AfterEach
+    @AfterAll
     fun tearDown() {
         dataSource.close()
     }

--- a/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/maksimum/BehandlingsDataTest.kt
@@ -32,14 +32,14 @@ import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import no.nav.aap.komponenter.json.DefaultJsonMapper
 import no.nav.aap.komponenter.type.Periode
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.*
 import java.util.*
 import kotlin.test.assertEquals
+import no.nav.aap.api.util.WithFakes
 
-
+@WithFakes
 class BehandlingsDataTest : PostgresTestBase() {
     companion object {
 
@@ -114,14 +114,6 @@ class BehandlingsDataTest : PostgresTestBase() {
             arenavedtak = emptyList(),
             muligMaksdato = null,
         )
-
-        private val fakes = Fakes()
-
-        @AfterAll
-        @JvmStatic
-        fun afterAll() {
-            Fakes().close()
-        }
     }
 
     @Test
@@ -134,9 +126,9 @@ class BehandlingsDataTest : PostgresTestBase() {
                 api(
                     config = config,
                     datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    aapHendelseProducer = fakes.aapHendelse,
+                    arenaService = Fakes.getArenaService(),
+                    modiaProducer = Fakes.getKafka(),
+                    aapHendelseProducer = Fakes.getAapHendelse(),
                 )
             }
 
@@ -192,9 +184,9 @@ class BehandlingsDataTest : PostgresTestBase() {
                 api(
                     config = config,
                     datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    aapHendelseProducer = fakes.aapHendelse,
+                    arenaService = Fakes.getArenaService(),
+                    modiaProducer = Fakes.getKafka(),
+                    aapHendelseProducer = Fakes.getAapHendelse(),
                 )
             }
 
@@ -242,9 +234,9 @@ class BehandlingsDataTest : PostgresTestBase() {
                 api(
                     config = config,
                     datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    aapHendelseProducer = fakes.aapHendelse,
+                    arenaService = Fakes.getArenaService(),
+                    modiaProducer = Fakes.getKafka(),
+                    aapHendelseProducer = Fakes.getAapHendelse(),
                 )
             }
 
@@ -292,7 +284,7 @@ class BehandlingsDataTest : PostgresTestBase() {
     private suspend fun ApplicationTestBuilder.settInnVedtak(
         azure: AzureTokenGen,
         periode: Periode,
-        fnr: String
+        fnr: String,
     ): HttpResponse {
         val fraOgMed = periode.fom
         return jsonHttpClient.post("/api/insert/vedtak") {
@@ -353,9 +345,9 @@ class BehandlingsDataTest : PostgresTestBase() {
                 api(
                     config = config,
                     datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    aapHendelseProducer = fakes.aapHendelse,
+                    arenaService = Fakes.getArenaService(),
+                    modiaProducer = Fakes.getKafka(),
+                    aapHendelseProducer = Fakes.getAapHendelse(),
                 )
             }
 
@@ -410,9 +402,9 @@ class BehandlingsDataTest : PostgresTestBase() {
                 api(
                     config = config,
                     datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    aapHendelseProducer = fakes.aapHendelse,
+                    arenaService = Fakes.getArenaService(),
+                    modiaProducer = Fakes.getKafka(),
+                    aapHendelseProducer = Fakes.getAapHendelse(),
                 )
             }
 
@@ -511,9 +503,9 @@ class BehandlingsDataTest : PostgresTestBase() {
                 api(
                     config = config,
                     datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    aapHendelseProducer = fakes.aapHendelse,
+                    arenaService = Fakes.getArenaService(),
+                    modiaProducer = Fakes.getKafka(),
+                    aapHendelseProducer = Fakes.getAapHendelse(),
                     // Setter nå-tidspunkt i framtiden for å kunne få utbetalinger
                     clock = clock
                 )
@@ -548,7 +540,6 @@ class BehandlingsDataTest : PostgresTestBase() {
             assertThat(uthentetFraApi).usingRecursiveComparison().isEqualTo(forventet)
         }
     }
-
 
 
     private val ApplicationTestBuilder.jsonHttpClient: HttpClient

--- a/app/src/test/kotlin/no/nav/aap/api/maksimum/KelvinOboTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/maksimum/KelvinOboTest.kt
@@ -2,13 +2,22 @@ package no.nav.aap.api.maksimum
 
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.request.*
-import io.ktor.http.*
-import io.ktor.serialization.jackson.*
-import io.ktor.server.testing.*
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
 import no.nav.aap.api.TestConfig
 import no.nav.aap.api.api
 import no.nav.aap.api.intern.InternVedtakRequestApiIntern
@@ -21,6 +30,7 @@ import no.nav.aap.api.intern.behandlingsflyt.SakstatusFraKelvin
 import no.nav.aap.api.util.AzureTokenGen
 import no.nav.aap.api.util.Fakes
 import no.nav.aap.api.util.PdlGatewayEmpty
+import no.nav.aap.api.util.WithFakes
 import no.nav.aap.behandlingsflyt.kontrakt.behandling.Status
 import no.nav.aap.behandlingsflyt.kontrakt.datadeling.DatadelingDTO
 import no.nav.aap.behandlingsflyt.kontrakt.datadeling.RettighetsTypePeriode
@@ -29,24 +39,23 @@ import no.nav.aap.behandlingsflyt.kontrakt.datadeling.TilkjentDTO
 import no.nav.aap.behandlingsflyt.kontrakt.statistikk.RettighetsType
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.util.*
+import org.junit.jupiter.api.TestInstance
 
+@WithFakes
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class KelvinOboTest {
 
     private lateinit var dataSource: TestDataSource
 
-    @BeforeEach
+    @BeforeAll
     fun setup() {
         dataSource = TestDataSource()
     }
 
-    @AfterEach
+    @AfterAll
     fun tearDown() = dataSource.close()
 
     private val fnr = "12345678910"
@@ -104,7 +113,6 @@ class KelvinOboTest {
 
     @Test
     fun `kan hente vedtak og sakstatus fra obo-endepunktet`() {
-        Fakes().use { fakes ->
             val azure = AzureTokenGen("test", "test")
 
             testApplication {
@@ -112,10 +120,10 @@ class KelvinOboTest {
                     api(
                         config = TestConfig.default(),
                         datasource = dataSource,
-                        arenaService = fakes.arenaService,
+                        arenaService = Fakes.getArenaService(),
                         pdlGateway = PdlGatewayEmpty(),
-                        aapHendelseProducer = fakes.aapHendelse,
-                        modiaProducer = fakes.kafka,
+                        aapHendelseProducer = Fakes.getAapHendelse(),
+                        modiaProducer = Fakes.getKafka(),
                     )
                 }
 
@@ -152,7 +160,6 @@ class KelvinOboTest {
                 assertThat(respons.vedtak.first().saksnummer).isEqualTo(saksnummer)
                 assertThat(respons.vedtak.first().rettighetsType).isEqualTo(RettighetsType.BISTANDSBEHOV.name)
             }
-        }
     }
 
     private val ApplicationTestBuilder.jsonHttpClient: HttpClient

--- a/app/src/test/kotlin/no/nav/aap/api/meldekort/MeldekortDetaljerTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/meldekort/MeldekortDetaljerTest.kt
@@ -23,11 +23,12 @@ import no.nav.aap.behandlingsflyt.kontrakt.datadeling.ArbeidIPeriodeDTO
 import no.nav.aap.behandlingsflyt.kontrakt.datadeling.DetaljertMeldekortDTO
 import no.nav.aap.behandlingsflyt.kontrakt.sak.Saksnummer
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import no.nav.aap.api.util.WithFakes
 
+@WithFakes
 class MeldekortDetaljerTest : PostgresTestBase() {
     companion object {
         val testMottatTidspunkt = localDateTime("2024-01-01 12:34:00")!!
@@ -49,14 +50,6 @@ class MeldekortDetaljerTest : PostgresTestBase() {
                 )
             ),
         )
-
-        private val fakes = Fakes()
-
-        @AfterAll
-        @JvmStatic
-        fun afterAll() {
-            Fakes().close()
-        }
     }
 
     @Test
@@ -69,9 +62,9 @@ class MeldekortDetaljerTest : PostgresTestBase() {
                 api(
                     config = config,
                     datasource = dataSource,
-                    arenaService = fakes.arenaService,
-                    modiaProducer = fakes.kafka,
-                    aapHendelseProducer = fakes.aapHendelse,
+                    arenaService = Fakes.getArenaService(),
+                    modiaProducer = Fakes.getKafka(),
+                    aapHendelseProducer = Fakes.getAapHendelse(),
                     pdlGateway = PdlGatewayEmpty(),
                 )
             }

--- a/app/src/test/kotlin/no/nav/aap/api/meldekortperioder/MeldekortPeriodeTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/meldekortperioder/MeldekortPeriodeTest.kt
@@ -24,12 +24,13 @@ import no.nav.aap.komponenter.type.Periode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import no.nav.aap.api.util.WithFakes
 
+@WithFakes
 class MeldekortPeriodeTest : PostgresTestBase() {
 
     @Test
     fun `kan lagre ned og hente meldekortperioder`() {
-        Fakes().use { fakes ->
             val config = TestConfig.default()
             val azure = AzureTokenGen("test", "test")
 
@@ -38,9 +39,9 @@ class MeldekortPeriodeTest : PostgresTestBase() {
                     api(
                         config = config,
                         datasource = dataSource,
-                        arenaService = fakes.arenaService,
-                        modiaProducer = fakes.kafka,
-                        aapHendelseProducer = fakes.aapHendelse,
+                        arenaService = Fakes.getArenaService(),
+                        modiaProducer = Fakes.getKafka(),
+                        aapHendelseProducer = Fakes.getAapHendelse(),
                         pdlGateway = PdlGatewayEmpty(),
                     )
                 }
@@ -92,11 +93,9 @@ class MeldekortPeriodeTest : PostgresTestBase() {
                 assert(meldekortPerioderResObo.status.isSuccess())
             }
         }
-    }
 
     @Test
     fun `kan lagre ned og hente aktivitetfase`() {
-        Fakes().use { fakes ->
 
             val config = TestConfig.default()
             val azure = AzureTokenGen("test", "test")
@@ -106,9 +105,9 @@ class MeldekortPeriodeTest : PostgresTestBase() {
                     api(
                         config = config,
                         datasource = dataSource,
-                        arenaService = fakes.arenaService,
-                        modiaProducer = fakes.kafka,
-                        aapHendelseProducer = fakes.aapHendelse,
+                        arenaService = Fakes.getArenaService(),
+                        modiaProducer = Fakes.getKafka(),
+                        aapHendelseProducer = Fakes.getAapHendelse(),
                         pdlGateway = PdlGatewayEmpty(),
                     )
                 }
@@ -155,7 +154,6 @@ class MeldekortPeriodeTest : PostgresTestBase() {
                 }
                 assert(aktivitetsfaseResM2m.status.isSuccess())
             }
-        }
     }
 
     private val ApplicationTestBuilder.jsonHttpClient: HttpClient

--- a/app/src/test/kotlin/no/nav/aap/api/meldekortperioder/SakStatusKelvinTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/meldekortperioder/SakStatusKelvinTest.kt
@@ -2,13 +2,19 @@ package no.nav.aap.api.meldekortperioder
 
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.request.*
-import io.ktor.http.*
-import io.ktor.serialization.jackson.*
-import io.ktor.server.testing.*
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import java.time.LocalDate
 import no.nav.aap.api.TestConfig
 import no.nav.aap.api.api
 import no.nav.aap.api.intern.KelvinStatus
@@ -19,27 +25,30 @@ import no.nav.aap.api.intern.behandlingsflyt.SakstatusFraKelvin
 import no.nav.aap.api.util.AzureTokenGen
 import no.nav.aap.api.util.Fakes
 import no.nav.aap.api.util.PdlGatewayEmpty
+import no.nav.aap.api.util.WithFakes
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
+import org.junit.jupiter.api.TestInstance
 
+@WithFakes
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SakStatusKelvinTest {
 
     private lateinit var dataSource: TestDataSource
 
-    @BeforeEach
+    @BeforeAll
     fun setup() {
         dataSource = TestDataSource()
     }
 
-    @AfterEach
+    @AfterAll
     fun tearDown() = dataSource.close()
 
 
@@ -61,7 +70,6 @@ class SakStatusKelvinTest {
 
     @Test
     fun `kan lagre ned og hente saker`() {
-        Fakes().use { fakes ->
             val config = TestConfig.default()
             val azure = AzureTokenGen("test", "test")
 
@@ -70,9 +78,9 @@ class SakStatusKelvinTest {
                     api(
                         config = config,
                         datasource = dataSource,
-                        arenaService = fakes.arenaService,
-                        modiaProducer = fakes.kafka,
-                        aapHendelseProducer = fakes.aapHendelse,
+                        arenaService = Fakes.getArenaService(),
+                        modiaProducer = Fakes.getKafka(),
+                        aapHendelseProducer = Fakes.getAapHendelse(),
                         pdlGateway = PdlGatewayEmpty(),
                     )
                 }
@@ -116,7 +124,6 @@ class SakStatusKelvinTest {
                     }
                 assertEquals(HttpStatusCode.OK, m2mResponse.status)
             }
-        }
     }
 
     private val ApplicationTestBuilder.jsonHttpClient: HttpClient

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/BehandlingsRepositoryTest.kt
@@ -1,30 +1,40 @@
 package no.nav.aap.api.postgres
 
-import no.nav.aap.api.kelvin.*
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+import no.nav.aap.api.kelvin.Arenavedtak
+import no.nav.aap.api.kelvin.Behandling
+import no.nav.aap.api.kelvin.GjeldendeStansEllerOpphør
+import no.nav.aap.api.kelvin.KelvinBehandlingStatus
+import no.nav.aap.api.kelvin.RettighetsTypePeriode
+import no.nav.aap.api.kelvin.Sak
+import no.nav.aap.api.kelvin.StansEllerOpphør
+import no.nav.aap.api.util.WithFakes
 import no.nav.aap.behandlingsflyt.kontrakt.statistikk.RettighetsType
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import no.nav.aap.komponenter.tidslinje.tidslinjeOf
 import no.nav.aap.komponenter.type.Periode
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.util.*
+import org.junit.jupiter.api.TestInstance
 
+@WithFakes
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BehandlingsRepositoryTest {
     private lateinit var dataSource: TestDataSource
 
-    @BeforeEach
+    @BeforeAll
     fun setUp() {
         dataSource = TestDataSource()
     }
 
-    @AfterEach
+    @AfterAll
     fun tearDown() {
         dataSource.close()
     }

--- a/app/src/test/kotlin/no/nav/aap/api/postgres/MeldekortDetaljerRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/postgres/MeldekortDetaljerRepositoryTest.kt
@@ -3,32 +3,37 @@ package no.nav.aap.api.postgres
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.random.Random
 import no.nav.aap.api.kelvin.Meldekort
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import no.nav.aap.komponenter.type.Periode
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MeldekortDetaljerRepositoryTest {
     private lateinit var dataSource: TestDataSource
 
-    @BeforeEach
+    @BeforeAll
     fun setUp() {
         dataSource = TestDataSource()
     }
 
-    @AfterEach
+    @AfterAll
     fun tearDown() {
         dataSource.close()
     }
 
     @Test
     fun `lagre og hente ut`() {
+        val ident = Random.nextLong(99999999999).toString()
+
         val meldekort = Meldekort(
-            personIdent = "12345678901",
+            personIdent = ident,
             saksnummer = "asd123",
             mottattTidspunkt = LocalDateTime.now(),
             behandlingId = 1234,
@@ -55,7 +60,7 @@ class MeldekortDetaljerRepositoryTest {
 
         val res = dataSource.transaction {
             MeldekortDetaljerRepository(it).hentAlle(
-                personIdentifikatorer = listOf("12345678901"),
+                personIdentifikatorer = listOf(ident),
                 fom = LocalDate.of(2025, 1, 1),
                 tom = LocalDate.of(2025, 12, 31)
             )
@@ -71,8 +76,10 @@ class MeldekortDetaljerRepositoryTest {
 
     @Test
     fun `lagre med nyere behandlingId erstatter eldre meldekort for samme sak`() {
+        val ident = Random.nextLong(99999999999).toString()
+
         val gammeltMeldekort = Meldekort(
-            personIdent = "12345678901",
+            personIdent = ident,
             saksnummer = "sak-1",
             mottattTidspunkt = LocalDateTime.now().minusDays(1),
             behandlingId = 10,
@@ -99,7 +106,7 @@ class MeldekortDetaljerRepositoryTest {
 
         val resultater = dataSource.transaction {
             MeldekortDetaljerRepository(it).hentAlle(
-                personIdentifikatorer = listOf("12345678901"),
+                personIdentifikatorer = listOf(ident),
                 fom = LocalDate.of(2025, 1, 1),
                 tom = LocalDate.of(2025, 12, 31)
             )

--- a/app/src/test/kotlin/no/nav/aap/api/util/Fakes.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/util/Fakes.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.api.util
 
+import behandlingsflyt.DialogmeldingEksistererDto
 import io.ktor.serialization.jackson.jackson
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -10,6 +11,7 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
+import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import java.util.UUID
@@ -30,6 +32,7 @@ class Fakes : AutoCloseable {
     val pdl = embeddedServer(Netty, port = 0, module = Application::pdlFake).start()
     val tilgang = embeddedServer(Netty, port = 0, module = Application::tilgangFake).start()
     val oppgave = embeddedServer(Netty, port = 0, module = Application::oppgaveFake).start()
+    val dokumentinnhenting = embeddedServer(Netty, port = 0, module = Application::dokumentinnhentingFake).start()
     val kafka = KafkaFake()
     val aapHendelse = AapHendelseKafkaFake()
     val arenaService = ArenaService(FakeArenaGateway(), FakeArenaGateway())
@@ -67,12 +70,17 @@ class Fakes : AutoCloseable {
         System.setProperty("INTEGRASJON_OPPGAVE_URL", "http://localhost:${oppgave.port()}")
         System.setProperty("INTEGRASJON_OPPGAVE_SCOPE", "scope")
 
+        // Dokumentinnhenting
+        System.setProperty("INTEGRASJON_DOKUMENTINNHENTING_URL", "http://localhost:${dokumentinnhenting.port()}")
+        System.setProperty("INTEGRASJON_DOKUMENTINNHENTING_SCOPE", "scope")
+
         // Meldekortbackend
         System.setProperty("AZP_MELDEKORT_BACKEND", UUID.randomUUID().toString())
         System.setProperty("AZP_SAAS_PROXY", UUID.randomUUID().toString())
         System.setProperty("AZP_TOKEN_GEN", UUID.randomUUID().toString())
         System.setProperty("AZP_TILLEGGSSTONADER_INTEGRASJONER", UUID.randomUUID().toString())
         System.setProperty("AZP_VEILARBOPPFOLGING", UUID.randomUUID().toString())
+        System.setProperty("AZP_PADM2", UUID.randomUUID().toString())
     }
 }
 
@@ -122,6 +130,17 @@ fun Application.oppgaveFake() {
                 EnhetOgOversendelse(
                     tilstand = null
                 )
+            )
+        }
+    }
+}
+
+fun Application.dokumentinnhentingFake() {
+    install(ContentNegotiation) { jackson() }
+    routing {
+        get("/dialogmelding/{dialogmeldingId}/eksisterer") {
+            call.respond(
+                DialogmeldingEksistererDto(eksisterer = true)
             )
         }
     }

--- a/app/src/test/kotlin/no/nav/aap/api/util/Fakes.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/util/Fakes.kt
@@ -43,6 +43,7 @@ class Fakes : AutoCloseable {
         oppgave.stop(0L, 0L)
         pdl.stop(0L, 0L)
         tilgang.stop(0L, 0L)
+        dokumentinnhenting.stop(0L, 0L)
         kafka.close()
         aapHendelse.close()
     }

--- a/app/src/test/kotlin/no/nav/aap/api/util/Fakes.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/util/Fakes.kt
@@ -26,16 +26,28 @@ import no.nav.aap.oppgave.enhet.EnhetOgOversendelse
 import no.nav.aap.oppgave.enhet.PersonRequest
 import no.nav.aap.tilgang.TilgangResponse
 
-class Fakes : AutoCloseable {
-    val texas = embeddedServer(Netty, port = 0, module = Application::texas).start()
-    val arena = embeddedServer(Netty, port = 0, module = Application::arena).start()
-    val pdl = embeddedServer(Netty, port = 0, module = Application::pdlFake).start()
-    val tilgang = embeddedServer(Netty, port = 0, module = Application::tilgangFake).start()
-    val oppgave = embeddedServer(Netty, port = 0, module = Application::oppgaveFake).start()
-    val dokumentinnhenting = embeddedServer(Netty, port = 0, module = Application::dokumentinnhentingFake).start()
-    val kafka = KafkaFake()
-    val aapHendelse = AapHendelseKafkaFake()
-    val arenaService = ArenaService(FakeArenaGateway(), FakeArenaGateway())
+object Fakes : AutoCloseable {
+    private val texas = embeddedServer(Netty, port = 0, module = Application::texas)
+    private val arena = embeddedServer(Netty, port = 0, module = Application::arena)
+    private val pdl = embeddedServer(Netty, port = 0, module = Application::pdlFake)
+    private val tilgang = embeddedServer(Netty, port = 0, module = Application::tilgangFake)
+    private val oppgave = embeddedServer(Netty, port = 0, module = Application::oppgaveFake)
+    private val dokumentinnhenting = embeddedServer(Netty, port = 0, module = Application::dokumentinnhentingFake)
+
+    private val kafka = KafkaFake()
+    private val aapHendelse = AapHendelseKafkaFake()
+    private val arenaService = ArenaService(FakeArenaGateway(), FakeArenaGateway())
+
+    fun start() {
+        texas.start()
+        arena.start()
+        pdl.start()
+        tilgang.start()
+        oppgave.start()
+        dokumentinnhenting.start()
+
+        setProperties()
+    }
 
     override fun close() {
         texas.stop(0L, 0L)
@@ -48,7 +60,17 @@ class Fakes : AutoCloseable {
         aapHendelse.close()
     }
 
-    init {
+    fun getArenaService() = arenaService
+
+    fun getArenaPort() = arena.port()
+
+    fun getKafka() = kafka
+
+    fun getAapHendelse() = aapHendelse
+
+    fun getTexasPort() = texas.port()
+
+    private fun setProperties() {
         // Texas
         System.setProperty("nais.token.endpoint", "http://localhost:${texas.port()}/token")
         System.setProperty("nais.token.exchange.endpoint", "http://localhost:${texas.port()}/token/exchange")

--- a/app/src/test/kotlin/no/nav/aap/api/util/WithFakes.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/util/WithFakes.kt
@@ -1,0 +1,16 @@
+package no.nav.aap.api.util
+
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class FakesExtension : BeforeAllCallback {
+    override fun beforeAll(context: ExtensionContext) {
+        Fakes.start()
+    }
+}
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ExtendWith(FakesExtension::class)
+annotation class WithFakes

--- a/kontrakt/src/main/kotlin/behandlingsflyt/DialogmeldingEksistererDto.kt
+++ b/kontrakt/src/main/kotlin/behandlingsflyt/DialogmeldingEksistererDto.kt
@@ -1,0 +1,3 @@
+package behandlingsflyt
+
+public data class DialogmeldingEksistererDto(val eksisterer: Boolean)


### PR DESCRIPTION
Nytt endepunkt for at Syfo skal kunne sjekke om en dialogmelding eksisterer i Kelvin. Dette for å unngå at det sendes til både Arena og Kelvin.