### PR TITLE
chore: fjern ubrukt endepunkt for arena-historikk

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/api/Routes.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/Routes.kt
@@ -26,7 +26,6 @@ import no.nav.aap.api.postgres.MeldekortPerioderRepository
 import no.nav.aap.api.postgres.SakStatusRepository
 import no.nav.aap.api.util.perioderMedAAp
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.komponenter.config.requiredConfigForKey
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
@@ -357,25 +356,6 @@ fun NormalOpenAPIRoute.api(
                 val eksistererIAAPArena =
                     arenaService.eksistererIAapArena(callId, requestBody.personidentifikatorer)
                 respond(eksistererIAAPArena)
-            }
-        }
-        route("/arena/person/aap/signifikant-historikk") {
-            post<CallIdHeader, SignifikanteSakerResponse, SignifikanteSakerRequest>(
-                info(description = "Sjekker om en person kan behandles i Kelvin mtp. AAP-Arena-historikken deres.")
-            ) { callIdHeader, requestBody ->
-                logger.info("Sjekker om personen kan behandles i Kelvin")
-                val callId = receiveCall(callIdHeader, pipeline)
-                pipeline.call.response.headers.append(
-                    HttpHeaders.ContentType,
-                    ContentType.Application.Json.withCharset(Charsets.UTF_8).toString()
-                )
-
-                val harSignifikantAAPArenaHistorikk = arenaService.harSignifikantAAPArenaHistorikk(
-                    callId,
-                    requestBody.personidentifikatorer,
-                    requestBody.virkningstidspunkt
-                )
-                respond(harSignifikantAAPArenaHistorikk)
             }
         }
         route("/arena/person/saker") {

--- a/app/src/main/kotlin/no/nav/aap/api/arena/ArenaService.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/arena/ArenaService.kt
@@ -7,7 +7,6 @@ import no.nav.aap.api.intern.PeriodeInkludert11_17
 import no.nav.aap.api.intern.PerioderInkludert11_17Response
 import no.nav.aap.api.intern.PersonEksistererIAAPArena
 import no.nav.aap.api.intern.SakStatus
-import no.nav.aap.api.intern.SignifikanteSakerResponse
 import no.nav.aap.api.intern.Vedtak
 import no.nav.aap.api.intern.VedtakUtenUtbetaling
 import no.nav.aap.api.util.fraKontrakt
@@ -15,9 +14,7 @@ import no.nav.aap.api.util.fraKontraktUtenUtbetaling
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.Status
-import java.time.LocalDate
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
 
 class ArenaService(
@@ -29,22 +26,6 @@ class ArenaService(
     suspend fun eksistererIAapArena(callId: String, personIdenter: List<String>): PersonEksistererIAAPArena {
         val aapHistorikkForPerson = arenaHistorikk.hentPersonEksistererIAapContext(callId, SakerRequest(personIdenter))
         return PersonEksistererIAAPArena(aapHistorikkForPerson.eksisterer)
-    }
-
-    suspend fun harSignifikantAAPArenaHistorikk(
-        callId: String,
-        personIdenter: List<String>,
-        virkningstidspunkt: LocalDate
-    ): SignifikanteSakerResponse {
-        val harSignifikantAAPArenaHistorikk =
-            arenaHistorikk.hentPersonHarSignifikantHistorikk(
-                callId,
-                SignifikanteSakerRequest(personIdenter, virkningstidspunkt)
-            )
-        return SignifikanteSakerResponse(
-            harSignifikantAAPArenaHistorikk.harSignifikantHistorikk,
-            harSignifikantAAPArenaHistorikk.signifikanteSaker
-        )
     }
 
     suspend fun aktivitetfase(callId: String, vedtakRequest: InternVedtakRequest): PerioderInkludert11_17Response {

--- a/app/src/main/kotlin/no/nav/aap/api/arena/ArenaoppslagGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/arena/ArenaoppslagGateway.kt
@@ -31,8 +31,6 @@ import no.nav.aap.arenaoppslag.kontrakt.intern.PerioderMed11_17Response
 import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakStatus
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Maksimum
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -134,14 +132,6 @@ class ArenaoppslagGateway(
             ).getOrThrow()
                 .also { personEksistererCache.put(key, it) }
     }
-
-    override suspend fun hentPersonHarSignifikantHistorikk(
-        callId: String,
-        req: SignifikanteSakerRequest,
-    ): SignifikanteSakerResponse =
-        gjørArenaOppslag<SignifikanteSakerResponse, SignifikanteSakerRequest>(
-            "/api/v1/person/signifikant-historikk", callId, req
-        ).getOrThrow()
 
     private suspend inline fun <reified T, reified V> gjørArenaOppslag(
         endepunkt: String, callId: String, req: V, tillattMed404: Boolean = false

--- a/app/src/main/kotlin/no/nav/aap/api/arena/IArenaoppslagGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/api/arena/IArenaoppslagGateway.kt
@@ -3,10 +3,8 @@ package no.nav.aap.api.arena
 import no.nav.aap.api.intern.PerioderResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.PerioderMed11_17Response
 import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Maksimum
@@ -23,10 +21,6 @@ interface IArenaoppslagGateway {
         req: SakerRequest
     ): PersonEksistererIAAPArena
 
-    suspend fun hentPersonHarSignifikantHistorikk(
-        callId: String,
-        req: SignifikanteSakerRequest
-    ): SignifikanteSakerResponse
 
     suspend fun hentSakerByFnr(
         callId: String,

--- a/app/src/test/kotlin/no/nav/aap/api/arena/ArenaOppslagTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/arena/ArenaOppslagTest.kt
@@ -14,18 +14,15 @@ import io.ktor.http.contentType
 import io.ktor.serialization.jackson.jackson
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
-import java.time.LocalDate
 import no.nav.aap.api.TestConfig
 import no.nav.aap.api.api
 import no.nav.aap.api.intern.PersonEksistererIAAPArena
-import no.nav.aap.api.intern.SignifikanteSakerResponse
 import no.nav.aap.api.util.AzureTokenGen
 import no.nav.aap.api.util.Fakes
 import no.nav.aap.api.util.WithFakes
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
@@ -75,22 +72,6 @@ class ArenaOppslagTest {
             val parsedBody = res.body<PersonEksistererIAAPArena>()
             assertThat(parsedBody).isNotNull
             assertThat(parsedBody.eksisterer).isFalse // forventet respons fra MockedArenaClient
-        }
-    }
-
-    @Test
-    fun `kan kalle på kan behandles i Kelvin`() {
-        testWithKtorApp { token ->
-            val res = jsonHttpClient.post("/arena/person/aap/signifikant-historikk") {
-                bearerAuth(token.generate(isApp = true))
-                contentType(ContentType.Application.Json)
-                setBody(SignifikanteSakerRequest(listOf("12345678910"), LocalDate.now()))
-            }
-            assertThat(res).isNotNull()
-            assertThat(res.status).isEqualTo(HttpStatusCode.OK)
-            val parsedBody = res.body<SignifikanteSakerResponse>()
-            assertThat(parsedBody).isNotNull
-            assertThat(parsedBody.harSignifikantHistorikk).isFalse // forventet respons fra MockedArenaClient
         }
     }
 

--- a/app/src/test/kotlin/no/nav/aap/api/util/ArenaEmpty.kt
+++ b/app/src/test/kotlin/no/nav/aap/api/util/ArenaEmpty.kt
@@ -9,8 +9,6 @@ import no.nav.aap.arenaoppslag.kontrakt.intern.PerioderMed11_17Response
 import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakStatus
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Maksimum
 import java.time.LocalDate
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
@@ -30,13 +28,6 @@ class FakeArenaGateway : IArenaoppslagGateway {
         callId: String, req: SakerRequest
     ): PersonEksistererIAAPArena {
         return PersonEksistererIAAPArena(false)
-    }
-
-    override suspend fun hentPersonHarSignifikantHistorikk(
-        callId: String,
-        req: SignifikanteSakerRequest
-    ): SignifikanteSakerResponse {
-        return SignifikanteSakerResponse(false, emptyList())
     }
 
     override suspend fun hentSakerByFnr(


### PR DESCRIPTION
Vi bruker andre endepunkter for arena-historikk nå, og kaller direkte fra postmottak til arenaoppslag